### PR TITLE
Export all teams and users

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,5 +19,5 @@ As a result, the file `output.yaml` in the current directory will provide the ca
 The following data will be exported/imported into the catalog:
 
 - All repositories referenced in the repositories lists in [giantswarm/github](https://github.com/giantswarm/github/tree/main/repositories) as _Component_ entities.
-- All owner teams of above components as _Group_ entities.
+- All teams of the configured Github organizaiton as _Group_ entities.
 - All members of the above teams as _User_ entities.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -94,9 +94,7 @@ func runRoot(cmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 
-	// Collect user names for User entity creation.
-	userNamesMap := make(map[string]bool, 1)
-
+	// Output buffer
 	var f bytes.Buffer
 
 	numComponents := 0
@@ -125,6 +123,9 @@ func runRoot(cmd *cobra.Command, args []string) {
 			}
 		}
 	}
+
+	// Collect user names for User entity creation.
+	userNamesMap := make(map[string]bool, 1)
 
 	// Export teams
 	teams, err := teamsService.GetAll()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -151,8 +151,6 @@ func runRoot(cmd *cobra.Command, args []string) {
 			parentTeamName = team.GetParent().GetSlug()
 		}
 
-		log.Printf("Team has %d members", len(memberNames))
-
 		entity := createGroupEntity(team.GetSlug(), team.GetName(), team.GetDescription(), parentTeamName, memberNames, team.GetID())
 
 		numTeams++

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -212,7 +212,10 @@ func runRoot(cmd *cobra.Command, args []string) {
 	}
 	defer file.Close()
 
+	var size int
+
 	if format == "raw" {
+		size = f.Len()
 		_, err = file.WriteString(f.String())
 		if err != nil {
 			log.Fatal(err)
@@ -239,17 +242,18 @@ func runRoot(cmd *cobra.Command, args []string) {
 			log.Fatalf("Error: %v", err)
 		}
 
+		size = buf.Len()
 		_, err = file.WriteString(buf.String())
 		if err != nil {
 			log.Fatal(err)
 		}
 	}
 
-	log.Printf("Wrote %d components, %d teams, %d users", numComponents, numTeams, numUsers)
+	log.Printf("Wrote %d components, %d groups, %d users", numComponents, numTeams, numUsers)
 	if format == "configmap" {
-		log.Printf("Wrote ConfigMap to %s", path)
+		log.Printf("Wrote ConfigMap to %s with size %d bytes", path, size)
 	} else {
-		log.Printf("Wrote YAML output to %s", path)
+		log.Printf("Wrote YAML output to %s with %d bytes", path, size)
 	}
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,6 +30,12 @@ var rootCmd = &cobra.Command{
 const (
 	// Name of the GitHub organization owning our teams and users.
 	githubOrganization = "giantswarm"
+
+	// Name of the repository holding our repository meta data.
+	githubManagementRepository = "github"
+
+	// Directory path within githubManagementRepository holding repo metadata YAML files.
+	repositoriesPath = "repositories"
 )
 
 func init() {
@@ -64,7 +70,17 @@ func runRoot(cmd *cobra.Command, args []string) {
 		log.Fatal("Invalid --format value. Please use 'raw' or 'configmap'.")
 	}
 
-	lists, err := repositories.GetLists(token)
+	repoService, err := repositories.New(repositories.Config{
+		GithubOrganization:   githubOrganization,
+		GithubRepositoryName: githubManagementRepository,
+		GithubAuthToken:      token,
+		DirectoryPath:        repositoriesPath,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	lists, err := repoService.GetLists()
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -116,7 +116,6 @@ func runRoot(cmd *cobra.Command, args []string) {
 	// Export teams
 	teamNames := getMapKeys(teamNamesMap)
 	for _, teamSlug := range teamNames {
-		log.Printf("Group %s", teamSlug)
 		team, _, err := client.Teams.GetTeamBySlug(ctx, githubOrganization, teamSlug)
 		if err != nil {
 			log.Fatalf("Error: %v", err)
@@ -155,7 +154,6 @@ func runRoot(cmd *cobra.Command, args []string) {
 	// Export users
 	userNames := getMapKeys(userNamesMap)
 	for _, userSlug := range userNames {
-		log.Printf("User %s", userSlug)
 
 		// load user data from Github
 		user, _, err := client.Users.Get(ctx, userSlug)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -179,6 +179,8 @@ func runRoot(cmd *cobra.Command, args []string) {
 
 	// Export users
 	userNames := getMapKeys(userNamesMap)
+	log.Printf("Processing %d users", len(userNames))
+
 	for _, userSlug := range userNames {
 
 		// load user data from Github

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/giantswarm/backstage-catalog-importer
 go 1.19
 
 require (
+	github.com/giantswarm/microerror v0.4.0
 	github.com/google/go-cmp v0.5.9
 	github.com/google/go-github/v53 v53.2.0
 	github.com/spf13/cobra v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/giantswarm/microerror v0.4.0 h1:QeU+UZL0rRlVXKqYOHMxS0L7g8UD+dn84NT7myWVh4U=
+github.com/giantswarm/microerror v0.4.0/go.mod h1:Ju1YdC6TX/8witv7fIlkgiRr5FQUNyq3f4TX2QYnO7c=
 github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.3 h1:2DntVwHkVopvECVRSlL5PSo9eG+cAkDCuckLubN+rq0=
 github.com/go-logr/logr v1.2.3/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/pkg/catalog/functions.go
+++ b/pkg/catalog/functions.go
@@ -1,0 +1,114 @@
+package catalog
+
+import (
+	"fmt"
+
+	"github.com/giantswarm/backstage-catalog-importer/pkg/repositories"
+)
+
+func CreateComponentEntity(r repositories.Repo, team string) Entity {
+	e := Entity{
+		APIVersion: "backstage.io/v1alpha1",
+		Kind:       EntityKindComponent,
+		Metadata: EntityMetadata{
+			Name:   r.Name,
+			Labels: map[string]string{},
+			Annotations: map[string]string{
+				"github.com/project-slug":      fmt.Sprintf("giantswarm/%s", r.Name),
+				"github.com/team-slug":         team,
+				"backstage.io/source-location": fmt.Sprintf("url:https://github.com/giantswarm/%s", r.Name),
+				"circleci.com/project-slug":    fmt.Sprintf("github/giantswarm/%s", r.Name),
+				"quay.io/repository-slug":      fmt.Sprintf("giantswarm/%s", r.Name),
+			},
+			Tags: []string{},
+		},
+	}
+
+	spec := ComponentSpec{
+		Type:      "service",
+		Lifecycle: "production",
+		Owner:     team,
+	}
+
+	if r.Lifecycle != "production" && r.Lifecycle != "" {
+		spec.Lifecycle = string(r.Lifecycle)
+	}
+
+	e.Spec = spec
+
+	if r.Gen.Language != "" && r.Gen.Language != repositories.RepoLanguageGeneric {
+		e.Metadata.Labels["giantswarm.io/language"] = string(r.Gen.Language)
+
+		e.Metadata.Tags = append(e.Metadata.Tags, fmt.Sprintf("language:%s", r.Gen.Language))
+	}
+
+	for _, flavor := range r.Gen.Flavors {
+		e.Metadata.Labels[fmt.Sprintf("giantswarm.io/flavor-%s", flavor)] = "true"
+
+		e.Metadata.Tags = append(e.Metadata.Tags, fmt.Sprintf("flavor:%s", flavor))
+	}
+
+	return e
+}
+
+func CreateGroupEntity(name, displayName, description, parent string, members []string, id int64) Entity {
+	e := Entity{
+		APIVersion: "backstage.io/v1alpha1",
+		Kind:       EntityKindGroup,
+		Metadata: EntityMetadata{
+			Name: name,
+		},
+	}
+	spec := GroupSpec{
+		Type:    "team",
+		Members: members,
+		Profile: GroupProfile{
+			Picture: fmt.Sprintf("https://avatars.githubusercontent.com/t/%d?s=116&v=4", id),
+		},
+	}
+
+	if description != "" {
+		e.Metadata.Description = description
+	}
+	if displayName != "" {
+		spec.Profile.DisplayName = displayName
+	}
+	if parent != "" {
+		spec.Parent = parent
+	}
+
+	e.Spec = spec
+
+	return e
+}
+
+func CreateUserEntity(name, email, displayName, description, avatarURL string) Entity {
+	e := Entity{
+		APIVersion: "backstage.io/v1alpha1",
+		Kind:       EntityKindUser,
+		Metadata: EntityMetadata{
+			Name: name,
+		},
+	}
+
+	spec := UserSpec{
+		MemberOf: []string{},
+		Profile: UserProfile{
+			Email: email,
+		},
+	}
+
+	if description != "" {
+		e.Metadata.Description = description
+	}
+	if displayName != "" {
+		spec.Profile.DisplayName = displayName
+	}
+	if avatarURL != "" {
+		spec.Profile.Picture = avatarURL
+	}
+
+	e.Spec = spec
+
+	return e
+}

--- a/pkg/repositories/errors.go
+++ b/pkg/repositories/errors.go
@@ -1,0 +1,7 @@
+package repositories
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}

--- a/pkg/repositories/repositories_test.go
+++ b/pkg/repositories/repositories_test.go
@@ -44,6 +44,7 @@ func TestLoadListShallow(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s, err := New(Config{
+				GithubAuthToken:      "abc",
 				GithubOrganization:   "foo",
 				GithubRepositoryName: "bar",
 				DirectoryPath:        "",
@@ -112,6 +113,7 @@ func TestLoadList(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s, err := New(Config{
+				GithubAuthToken:      "abc",
 				GithubOrganization:   "foo",
 				GithubRepositoryName: "bar",
 				DirectoryPath:        "",

--- a/pkg/repositories/repositories_test.go
+++ b/pkg/repositories/repositories_test.go
@@ -43,7 +43,15 @@ func TestLoadListShallow(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := LoadList(tt.path)
+			s, err := New(Config{
+				GithubOrganization:   "foo",
+				GithubRepositoryName: "bar",
+				DirectoryPath:        "",
+			})
+			if err != nil {
+				t.Errorf("unexpected error %v", err)
+			}
+			_, err = s.LoadList(tt.path)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("LoadList() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -103,7 +111,16 @@ func TestLoadList(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := LoadList(tt.args.path)
+			s, err := New(Config{
+				GithubOrganization:   "foo",
+				GithubRepositoryName: "bar",
+				DirectoryPath:        "",
+			})
+			if err != nil {
+				t.Errorf("unexpected error %v", err)
+			}
+
+			got, err := s.LoadList(tt.args.path)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("LoadList() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/teams/errors.go
+++ b/pkg/teams/errors.go
@@ -1,0 +1,7 @@
+package teams
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}

--- a/pkg/teams/teams.go
+++ b/pkg/teams/teams.go
@@ -1,0 +1,90 @@
+package teams
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/google/go-github/v53/github"
+	"golang.org/x/oauth2"
+)
+
+type Config struct {
+	// Name of the GitHub organization owning our repository.
+	GithubOrganization string
+
+	// Github personal access token (PTA) to use for client authentication.
+	GithubAuthToken string
+}
+
+type Service struct {
+	config       Config
+	ctx          context.Context
+	githubClient *github.Client
+}
+
+// New instantiates a new teams service.
+func New(c Config) (*Service, error) {
+	if c.GithubOrganization == "" {
+		return nil, microerror.Maskf(invalidConfigError, "no Github organization configured")
+	}
+	if c.GithubAuthToken == "" {
+		return nil, microerror.Maskf(invalidConfigError, "no Github token given")
+	}
+
+	ts := oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: c.GithubAuthToken},
+	)
+
+	ctx := context.Background()
+	tc := oauth2.NewClient(ctx, ts)
+	client := github.NewClient(tc)
+
+	s := &Service{
+		config:       c,
+		ctx:          ctx,
+		githubClient: client,
+	}
+
+	return s, nil
+}
+
+// Return all teams in the Github organization.
+func (s *Service) GetAll() ([]*github.Team, error) {
+	opts := &github.ListOptions{}
+	teams := []*github.Team{}
+	for {
+		t, resp, err := s.githubClient.Teams.ListTeams(s.ctx, s.config.GithubOrganization, opts)
+		if err != nil {
+			return nil, err
+		}
+
+		teams = append(teams, t...)
+
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+	return teams, nil
+}
+
+// Return member users for a team
+func (s *Service) GetMembers(teamSlug string) ([]*github.User, error) {
+	opts := &github.TeamListTeamMembersOptions{}
+	members := []*github.User{}
+	for {
+		m, resp, err := s.githubClient.Teams.ListTeamMembersBySlug(s.ctx, s.config.GithubOrganization, teamSlug, opts)
+		if err != nil {
+			return nil, err
+		}
+
+		members = append(members, m...)
+
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+
+	return members, nil
+}


### PR DESCRIPTION
### What does this PR do?

This PR changes the export logic to cover all GitHub teams and users we have in our organization.

In addition, some refactoring is done to move logic out of the root function. Also the exported file's size is logged in the end.

### What is the effect of this change to users?

- All our staff members will be able to access the dev portal.
- All teams will be browseable as Group entities in the catalog.

### How does it look like?

Logging:

```
...
2023/07/26 10:28:37 Processing 99 teams
2023/07/26 10:29:11 Wrote 363 components, 99 groups, 86 users
2023/07/26 10:29:11 Wrote ConfigMap to output.yaml with size 309468 bytes
```

Not showing teams and groups data here for privacy reasons.

### Any background context you can provide?

https://github.com/giantswarm/giantswarm/issues/27008

### Do the docs need to be updated?

Yes, done

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
