### PR TITLE
Ensure members array is sorted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Sort Group members alphanumerically.
+
 ## [0.0.4] - 2023-07-26
 
 - Treat all GitHub teams in the organization, instead of only the teams owning repositories.

--- a/pkg/catalog/functions.go
+++ b/pkg/catalog/functions.go
@@ -2,6 +2,7 @@ package catalog
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/giantswarm/backstage-catalog-importer/pkg/repositories"
 )
@@ -52,6 +53,7 @@ func CreateComponentEntity(r repositories.Repo, team string) Entity {
 }
 
 func CreateGroupEntity(name, displayName, description, parent string, members []string, id int64) Entity {
+	sort.Strings(members)
 	e := Entity{
 		APIVersion: "backstage.io/v1alpha1",
 		Kind:       EntityKindGroup,


### PR DESCRIPTION
### What does this PR do?

This ensures that a group's members list is sorted, to avoid meaningless changes which only affect the order, but not the actual members.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
