### PR TITLE
Export repository description, visibility=private to component entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Export repository descriptions to component entities.
+
 ## [0.0.5] - 2023-07-26
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Export repository descriptions to component entities.
+- Export repository visibility (private) to component entity tags.
 
 ## [0.0.5] - 2023-07-26
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -106,7 +106,7 @@ func runRoot(cmd *cobra.Command, args []string) {
 		log.Printf("Processing %d repos of team %q\n", len(list.Repositories), list.OwnerTeamName)
 
 		for _, repo := range list.Repositories {
-			ent := catalog.CreateComponentEntity(repo, list.OwnerTeamName)
+			ent := catalog.CreateComponentEntity(repo, list.OwnerTeamName, repoService.GetDescription(repo.Name))
 			numComponents++
 
 			d, err := yaml.Marshal(&ent)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -106,7 +106,16 @@ func runRoot(cmd *cobra.Command, args []string) {
 		log.Printf("Processing %d repos of team %q\n", len(list.Repositories), list.OwnerTeamName)
 
 		for _, repo := range list.Repositories {
-			ent := catalog.CreateComponentEntity(repo, list.OwnerTeamName, repoService.GetDescription(repo.Name))
+			isPrivate, err := repoService.GetIsPrivate(repo.Name)
+			if err != nil {
+				log.Fatalf("Error: %v", err)
+			}
+
+			ent := catalog.CreateComponentEntity(
+				repo,
+				list.OwnerTeamName,
+				repoService.GetDescription(repo.Name),
+				isPrivate)
 			numComponents++
 
 			d, err := yaml.Marshal(&ent)
@@ -152,7 +161,13 @@ func runRoot(cmd *cobra.Command, args []string) {
 			parentTeamName = team.GetParent().GetSlug()
 		}
 
-		entity := catalog.CreateGroupEntity(team.GetSlug(), team.GetName(), team.GetDescription(), parentTeamName, memberNames, team.GetID())
+		entity := catalog.CreateGroupEntity(
+			team.GetSlug(),
+			team.GetName(),
+			team.GetDescription(),
+			parentTeamName,
+			memberNames,
+			team.GetID())
 
 		numTeams++
 

--- a/pkg/catalog/functions.go
+++ b/pkg/catalog/functions.go
@@ -7,13 +7,14 @@ import (
 	"github.com/giantswarm/backstage-catalog-importer/pkg/repositories"
 )
 
-func CreateComponentEntity(r repositories.Repo, team string) Entity {
+func CreateComponentEntity(r repositories.Repo, team, description string) Entity {
 	e := Entity{
 		APIVersion: "backstage.io/v1alpha1",
 		Kind:       EntityKindComponent,
 		Metadata: EntityMetadata{
-			Name:   r.Name,
-			Labels: map[string]string{},
+			Name:        r.Name,
+			Labels:      map[string]string{},
+			Description: description,
 			Annotations: map[string]string{
 				"github.com/project-slug":      fmt.Sprintf("giantswarm/%s", r.Name),
 				"github.com/team-slug":         team,

--- a/pkg/catalog/functions.go
+++ b/pkg/catalog/functions.go
@@ -7,7 +7,7 @@ import (
 	"github.com/giantswarm/backstage-catalog-importer/pkg/repositories"
 )
 
-func CreateComponentEntity(r repositories.Repo, team, description string) Entity {
+func CreateComponentEntity(r repositories.Repo, team, description string, isPrivate bool) Entity {
 	e := Entity{
 		APIVersion: "backstage.io/v1alpha1",
 		Kind:       EntityKindComponent,
@@ -42,6 +42,10 @@ func CreateComponentEntity(r repositories.Repo, team, description string) Entity
 		e.Metadata.Labels["giantswarm.io/language"] = string(r.Gen.Language)
 
 		e.Metadata.Tags = append(e.Metadata.Tags, fmt.Sprintf("language:%s", r.Gen.Language))
+	}
+
+	if isPrivate {
+		e.Metadata.Tags = append(e.Metadata.Tags, "private")
 	}
 
 	for _, flavor := range r.Gen.Flavors {

--- a/pkg/repositories/errors.go
+++ b/pkg/repositories/errors.go
@@ -5,3 +5,7 @@ import "github.com/giantswarm/microerror"
 var invalidConfigError = &microerror.Error{
 	Kind: "invalidConfigError",
 }
+
+var repositoryNotFoundError = &microerror.Error{
+	Kind: "repositoryNotFoundError",
+}

--- a/pkg/repositories/repositories.go
+++ b/pkg/repositories/repositories.go
@@ -39,6 +39,7 @@ type ListResult struct {
 type GithubRepo struct {
 	Name        string
 	Description string
+	IsPrivate   bool
 }
 
 type Service struct {
@@ -103,6 +104,7 @@ func (s *Service) loadGithubRepoData() (map[string]GithubRepo, error) {
 			repos[repo.GetName()] = GithubRepo{
 				Name:        repo.GetName(),
 				Description: repo.GetDescription(),
+				IsPrivate:   repo.GetPrivate(),
 			}
 		}
 
@@ -180,4 +182,13 @@ func (s *Service) GetDescription(name string) string {
 		return repo.Description
 	}
 	return ""
+}
+
+// Returns the public/private info for the given repo. If not available,
+// return an error.
+func (s *Service) GetIsPrivate(name string) (bool, error) {
+	if repo, ok := s.githubRepos[name]; ok {
+		return repo.IsPrivate, nil
+	}
+	return false, microerror.Maskf(repositoryNotFoundError, "repository %s not found", name)
 }

--- a/pkg/repositories/repositories.go
+++ b/pkg/repositories/repositories.go
@@ -35,10 +35,17 @@ type ListResult struct {
 	Repositories  []Repo
 }
 
+// GithubRepo is a sparce struct for just the GitHub repository info we need.
+type GithubRepo struct {
+	Name        string
+	Description string
+}
+
 type Service struct {
 	config       Config
 	ctx          context.Context
 	githubClient *github.Client
+	githubRepos  map[string]GithubRepo
 }
 
 // New instantiates a new repositories service.
@@ -67,22 +74,60 @@ func New(c Config) (*Service, error) {
 		githubClient: client,
 	}
 
+	repos, err := s.loadGithubRepoData()
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	s.githubRepos = repos
+
 	return s, nil
 }
 
-// LoadList loads a list of repository configurations from a local path.
+// Load repository metadata from Github.
+func (s *Service) loadGithubRepoData() (map[string]GithubRepo, error) {
+	opts := &github.RepositoryListByOrgOptions{
+		ListOptions: github.ListOptions{
+			PerPage: 100,
+		},
+	}
+	repos := make(map[string]GithubRepo)
+
+	for {
+		r, resp, err := s.githubClient.Repositories.ListByOrg(s.ctx, s.config.GithubOrganization, opts)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, repo := range r {
+			repos[repo.GetName()] = GithubRepo{
+				Name:        repo.GetName(),
+				Description: repo.GetDescription(),
+			}
+		}
+
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+
+	return repos, nil
+}
+
+// Loads a list of repository configurations from a local path.
 // The file name is asserted in the format `<team_name>.yaml`, with all
 // repositories mentioned in it belonging to the team of that name.
-func (s *Service) LoadList(path string) ([]Repo, error) {
+func (s *Service) loadList(path string) ([]Repo, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.LoadListFromBytes(data)
+	return s.loadListFromBytes(data)
 }
 
-func (s *Service) LoadListFromBytes(data []byte) ([]Repo, error) {
+func (s *Service) loadListFromBytes(data []byte) ([]Repo, error) {
 	repos := []Repo{}
 	err := yaml.UnmarshalStrict(data, &repos)
 	if err != nil {
@@ -94,6 +139,7 @@ func (s *Service) LoadListFromBytes(data []byte) ([]Repo, error) {
 
 // GetLists loads the lists of repository YAML files from GitHub giantswarm/github.
 func (s *Service) GetLists() ([]ListResult, error) {
+	// Get repositories directory content.
 	_, directoryContent, _, err := s.githubClient.Repositories.GetContents(s.ctx, s.config.GithubOrganization, s.config.GithubRepositoryName, s.config.DirectoryPath, nil)
 	if err != nil {
 		return nil, err
@@ -106,13 +152,14 @@ func (s *Service) GetLists() ([]ListResult, error) {
 			continue
 		}
 
+		// Get individual team repositories file.
 		fileContent, _, _, err := s.githubClient.Repositories.GetContents(s.ctx, s.config.GithubOrganization, s.config.GithubRepositoryName, *item.Path, nil)
 		if err != nil {
 			return nil, err
 		}
 
 		decodedContent, _ := b64.StdEncoding.DecodeString(*fileContent.Content)
-		lists, err := s.LoadListFromBytes(decodedContent)
+		lists, err := s.loadListFromBytes(decodedContent)
 		if err != nil {
 			return nil, err
 		}
@@ -124,4 +171,13 @@ func (s *Service) GetLists() ([]ListResult, error) {
 	}
 
 	return result, nil
+}
+
+// Returns the description for the given repo. If not available,
+// returns an empty string.
+func (s *Service) GetDescription(name string) string {
+	if repo, ok := s.githubRepos[name]; ok {
+		return repo.Description
+	}
+	return ""
 }

--- a/pkg/repositories/repositories_test.go
+++ b/pkg/repositories/repositories_test.go
@@ -52,7 +52,7 @@ func TestLoadListShallow(t *testing.T) {
 			if err != nil {
 				t.Errorf("unexpected error %v", err)
 			}
-			_, err = s.LoadList(tt.path)
+			_, err = s.loadList(tt.path)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("LoadList() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -122,7 +122,7 @@ func TestLoadList(t *testing.T) {
 				t.Errorf("unexpected error %v", err)
 			}
 
-			got, err := s.LoadList(tt.args.path)
+			got, err := s.loadList(tt.args.path)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("LoadList() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
### What does this PR do?

- Adds descriptions to component entities
- Adds tag `private` on component with private repository

Descriptions are read from the GitHub repository data.

### What is the effect of this change to users?

Many entitites in the catalog will show a description both on the index page and in the details page. Private repos will have the tag `private`. Public ones won't have a corresponding tag, as public is our default.

### How does it look like?

Index:

<img width="1117" alt="image" src="https://github.com/giantswarm/backstage-catalog-importer/assets/273727/30d15ffd-fa88-407c-a6e4-bdf81c9c43db">

<img width="435" alt="image" src="https://github.com/giantswarm/backstage-catalog-importer/assets/273727/c368b4fc-2df2-4fae-846c-b7b7b666f01e">


Details:

<img width="678" alt="image" src="https://github.com/giantswarm/backstage-catalog-importer/assets/273727/4df55bd0-8300-4f27-ac5f-bac9f5c75abd">

### Any background context you can provide?

Improvements in the context of https://github.com/giantswarm/giantswarm/issues/27008

### Do the docs need to be updated?

No

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
