### PR TITLE
Add CircleCI annotation only if there is a config; Add techdocs annotation in case there is a README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Only create `circleci.com/project-slug` annotation on component if there is a `.circleci/config.yml` file.
+
 ## [0.0.6] - 2023-07-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `backstage.io/techdocs-ref` annotation for components (only if `/README.md` is present).
+
 ### Changed
 
 - Only create `circleci.com/project-slug` annotation on component if there is a `.circleci/config.yml` file.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -116,12 +116,19 @@ func runRoot(cmd *cobra.Command, args []string) {
 				log.Fatalf("Error: %v", err)
 			}
 
+			hasReadme, err := repoService.GetHasReadme(repo.Name)
+			if err != nil {
+				log.Fatalf("Error: %v", err)
+			}
+
 			ent := catalog.CreateComponentEntity(
 				repo,
 				list.OwnerTeamName,
 				repoService.MustGetDescription(repo.Name),
 				isPrivate,
-				hasCircleCi)
+				hasCircleCi,
+				hasReadme,
+				repoService.MustGetDefaultBranch(repo.Name))
 			numComponents++
 
 			d, err := yaml.Marshal(&ent)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -111,11 +111,17 @@ func runRoot(cmd *cobra.Command, args []string) {
 				log.Fatalf("Error: %v", err)
 			}
 
+			hasCircleCi, err := repoService.GetHasCircleCI(repo.Name)
+			if err != nil {
+				log.Fatalf("Error: %v", err)
+			}
+
 			ent := catalog.CreateComponentEntity(
 				repo,
 				list.OwnerTeamName,
-				repoService.GetDescription(repo.Name),
-				isPrivate)
+				repoService.MustGetDescription(repo.Name),
+				isPrivate,
+				hasCircleCi)
 			numComponents++
 
 			d, err := yaml.Marshal(&ent)

--- a/pkg/catalog/functions.go
+++ b/pkg/catalog/functions.go
@@ -7,7 +7,7 @@ import (
 	"github.com/giantswarm/backstage-catalog-importer/pkg/repositories"
 )
 
-func CreateComponentEntity(r repositories.Repo, team, description string, isPrivate bool) Entity {
+func CreateComponentEntity(r repositories.Repo, team, description string, isPrivate bool, hasCircleCi bool) Entity {
 	e := Entity{
 		APIVersion: "backstage.io/v1alpha1",
 		Kind:       EntityKindComponent,
@@ -19,11 +19,14 @@ func CreateComponentEntity(r repositories.Repo, team, description string, isPriv
 				"github.com/project-slug":      fmt.Sprintf("giantswarm/%s", r.Name),
 				"github.com/team-slug":         team,
 				"backstage.io/source-location": fmt.Sprintf("url:https://github.com/giantswarm/%s", r.Name),
-				"circleci.com/project-slug":    fmt.Sprintf("github/giantswarm/%s", r.Name),
 				"quay.io/repository-slug":      fmt.Sprintf("giantswarm/%s", r.Name),
 			},
 			Tags: []string{},
 		},
+	}
+
+	if hasCircleCi {
+		e.Metadata.Annotations["circleci.com/project-slug"] = fmt.Sprintf("github/giantswarm/%s", r.Name)
 	}
 
 	spec := ComponentSpec{

--- a/pkg/catalog/functions.go
+++ b/pkg/catalog/functions.go
@@ -30,7 +30,7 @@ func CreateComponentEntity(r repositories.Repo, team, description string, isPriv
 	}
 
 	if hasReadme && defaultBranch != "" {
-		e.Metadata.Annotations["backstage.io/techdocs-ref"] = fmt.Sprintf("url:https://github.com/giantswarm/%s/%s", r.Name, defaultBranch)
+		e.Metadata.Annotations["backstage.io/techdocs-ref"] = fmt.Sprintf("url:https://github.com/giantswarm/%s/tree/%s", r.Name, defaultBranch)
 	}
 
 	spec := ComponentSpec{

--- a/pkg/catalog/functions.go
+++ b/pkg/catalog/functions.go
@@ -7,7 +7,7 @@ import (
 	"github.com/giantswarm/backstage-catalog-importer/pkg/repositories"
 )
 
-func CreateComponentEntity(r repositories.Repo, team, description string, isPrivate bool, hasCircleCi bool) Entity {
+func CreateComponentEntity(r repositories.Repo, team, description string, isPrivate bool, hasCircleCi, hasReadme bool, defaultBranch string) Entity {
 	e := Entity{
 		APIVersion: "backstage.io/v1alpha1",
 		Kind:       EntityKindComponent,
@@ -27,6 +27,10 @@ func CreateComponentEntity(r repositories.Repo, team, description string, isPriv
 
 	if hasCircleCi {
 		e.Metadata.Annotations["circleci.com/project-slug"] = fmt.Sprintf("github/giantswarm/%s", r.Name)
+	}
+
+	if hasReadme && defaultBranch != "" {
+		e.Metadata.Annotations["backstage.io/techdocs-ref"] = fmt.Sprintf("url:https://github.com/giantswarm/%s/%s", r.Name, defaultBranch)
 	}
 
 	spec := ComponentSpec{

--- a/pkg/repositories/repositories.go
+++ b/pkg/repositories/repositories.go
@@ -6,7 +6,6 @@ package repositories
 import (
 	"context"
 	b64 "encoding/base64"
-	"log"
 	"os"
 	"strings"
 
@@ -86,8 +85,6 @@ func New(c Config) (*Service, error) {
 
 // Load information for a specific repo from the Github API.
 func (s *Service) loadGithubRepoDetails(name string) error {
-	log.Printf("Fetching details for repo %s", name)
-
 	repo, _, err := s.githubClient.Repositories.Get(s.ctx, s.config.GithubOrganization, name)
 	if err != nil {
 		return err


### PR DESCRIPTION
### What does this PR do?

This PR changes the importer so that the CircleCI project slug annotation is only written if the repository has a CircleCI configuration file.

Also a techdocs-related annotation is added to components (when there is a /README.md file in the repo). This will eventually enable the displaying of documentation in the portal (https://github.com/giantswarm/giantswarm/issues/27732).

### What is the effect of this change to users?

Users will no longer get an error when accessing the CircleCI tab for a component that does not have CircleCI configured.

Also users will eventually see the component's README as techdocs in the portal.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
