### PR TITLE
Accept componentType property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Accept `componentType` property when reading repository data.
+
 ## [0.0.7] - 2023-08-02
 
 ### Added

--- a/pkg/repositories/types.go
+++ b/pkg/repositories/types.go
@@ -1,11 +1,12 @@
 package repositories
 
 type Repo struct {
-	Name         string           `yaml:"name"`
-	Gen          RepoGen          `yaml:"gen"`
-	Lifecycle    RepoLifecycle    `yaml:"lifecycle"`
-	Replacements RepoReplacements `yaml:"replace"`
-	AppTestSuite interface{}      `yaml:"app_test_suite"`
+	Name          string           `yaml:"name"`
+	ComponentType string           `yaml:"componentType"`
+	Gen           RepoGen          `yaml:"gen"`
+	Lifecycle     RepoLifecycle    `yaml:"lifecycle"`
+	Replacements  RepoReplacements `yaml:"replace"`
+	AppTestSuite  interface{}      `yaml:"app_test_suite"`
 }
 
 type RepoFlavor string


### PR DESCRIPTION
### What does this PR do?

Fixes the catalog data import.

This PR mitigates the problem that the component will fail when repository data provides the `componentType` property.

See https://github.com/giantswarm/github/actions/runs/5782821021/job/15670389308 for an example.

We don't do anything with the value yet.

### What is the effect of this change to users?

CI runs for importing catalog data should succeed again.