### PR TITLE
Export component type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Set a component type based on the data read from giantswarm/github.
+
 ## [0.0.8] - 2023-08-07
 
 ### Fixed

--- a/pkg/catalog/functions.go
+++ b/pkg/catalog/functions.go
@@ -34,9 +34,13 @@ func CreateComponentEntity(r repositories.Repo, team, description string, isPriv
 	}
 
 	spec := ComponentSpec{
-		Type:      "service",
+		Type:      "unspecified",
 		Lifecycle: "production",
 		Owner:     team,
+	}
+
+	if r.ComponentType != "" {
+		spec.Type = r.ComponentType
 	}
 
 	if r.Lifecycle != "production" && r.Lifecycle != "" {


### PR DESCRIPTION
### What does this PR do?

This PR sets a component entity's `.spec.type` field according to the `componentType` imported from giantswarm/github repo metadata.

If no component type is specified, the value `unspecified` is exported as a default, as the catalog entity schema requires the `.spec.type` property to be set.

### What is the effect of this change to users?

- In a component overview, the specific type will appear where users currently see `service` for everything.

- The other details shown for a component might adapt based on the type (to be implemented in giantswarm/backstage).

### How does it look like?

Example for type `library`

```yaml
apiVersion: backstage.io/v1alpha1
kind: Component
metadata:
  name: backoff
  description: A library to abstract retry functionality
  labels:
    giantswarm.io/flavor-generic: "true"
    giantswarm.io/language: go
  annotations:
    backstage.io/source-location: url:https://github.com/giantswarm/backoff
    backstage.io/techdocs-ref: url:https://github.com/giantswarm/backoff/tree/main
    circleci.com/project-slug: github/giantswarm/backoff
    github.com/project-slug: giantswarm/backoff
    github.com/team-slug: team-atlas
    quay.io/repository-slug: giantswarm/backoff
  tags:
  - language:go
  - flavor:generic
spec:
  type: library
  lifecycle: production
  owner: team-atlas
```

![image](https://github.com/giantswarm/backstage-catalog-importer/assets/273727/b3e65da6-c279-4f78-8a9d-1e7d3650219b)

### Any background context you can provide?

Towards https://github.com/giantswarm/giantswarm/issues/27739

### Do the docs need to be updated?

No

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
