### PR TITLE
Export dependencies in Go components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Export `dependsOn` relationships between a Go component and the libraries it is using (if the library is ours).
+
 ## [0.0.9] - 2023-08-08
 
 ### Added

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -121,6 +121,17 @@ func runRoot(cmd *cobra.Command, args []string) {
 				log.Fatalf("Error: %v", err)
 			}
 
+			deps := []string{}
+			lang := repoService.MustGetLanguage(repo.Name)
+
+			if lang == "go" {
+				deps, err = repoService.GetDependencies(repo.Name)
+				if err != nil {
+					log.Printf("WARN - %s: error fetching dependencies: %v", repo.Name, err)
+				}
+				fmt.Printf("Dependencies: %v\n", deps)
+			}
+
 			ent := catalog.CreateComponentEntity(
 				repo,
 				list.OwnerTeamName,
@@ -128,7 +139,8 @@ func runRoot(cmd *cobra.Command, args []string) {
 				isPrivate,
 				hasCircleCi,
 				hasReadme,
-				repoService.MustGetDefaultBranch(repo.Name))
+				repoService.MustGetDefaultBranch(repo.Name),
+				deps)
 			numComponents++
 
 			d, err := yaml.Marshal(&ent)

--- a/pkg/catalog/functions.go
+++ b/pkg/catalog/functions.go
@@ -7,7 +7,7 @@ import (
 	"github.com/giantswarm/backstage-catalog-importer/pkg/repositories"
 )
 
-func CreateComponentEntity(r repositories.Repo, team, description string, isPrivate bool, hasCircleCi, hasReadme bool, defaultBranch string) Entity {
+func CreateComponentEntity(r repositories.Repo, team, description string, isPrivate bool, hasCircleCi, hasReadme bool, defaultBranch string, dependsOn []string) Entity {
 	e := Entity{
 		APIVersion: "backstage.io/v1alpha1",
 		Kind:       EntityKindComponent,
@@ -45,6 +45,12 @@ func CreateComponentEntity(r repositories.Repo, team, description string, isPriv
 
 	if r.Lifecycle != "production" && r.Lifecycle != "" {
 		spec.Lifecycle = string(r.Lifecycle)
+	}
+
+	if len(dependsOn) > 0 {
+		for _, d := range dependsOn {
+			spec.DependsOn = append(spec.DependsOn, "component:"+d)
+		}
 	}
 
 	e.Spec = spec

--- a/pkg/repositories/dependencies.go
+++ b/pkg/repositories/dependencies.go
@@ -42,18 +42,11 @@ func (s *Service) GetDependencies(name string) ([]string, error) {
 	}
 
 	godepRegex := regexp.MustCompile("go:github.com/giantswarm/([^/]+).*")
-	actionRegex := regexp.MustCompile("actions:giantswarm/([^/]+).*")
 
 	for _, item := range payload.Sbom.Packages {
-		// We only want either of these:
+		// We only want these:
 		// 'go:github.com/giantswarm/NAME'
-		// 'actions:giantswarm/NAME'
 		matches := godepRegex.FindStringSubmatch(item.Name)
-		if len(matches) > 0 {
-			names = append(names, matches[1])
-		}
-
-		matches = actionRegex.FindStringSubmatch(item.Name)
 		if len(matches) > 0 {
 			names = append(names, matches[1])
 		}

--- a/pkg/repositories/dependencies.go
+++ b/pkg/repositories/dependencies.go
@@ -1,0 +1,63 @@
+package repositories
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/google/go-github/v53/github"
+)
+
+type SbomPayload struct {
+	Sbom Sbom `json:"sbom"`
+}
+
+type Sbom struct {
+	Name     string        `json:"name"`
+	Packages []SbomPackage `json:"packages"`
+}
+
+type SbomPackage struct {
+	Name string `json:"name"`
+}
+
+// Returns list of dependencies.
+//
+// As long as https://github.com/google/go-github/issues/2864 is open,
+// we have to make this a low-level request.
+func (s *Service) GetDependencies(name string) ([]string, error) {
+	path := fmt.Sprintf("/repos/%s/%s/dependency-graph/sbom", s.config.GithubOrganization, name)
+	req, err := s.githubClient.NewRequest("GET", path, nil, github.WithVersion("2022-11-28"))
+	if err != nil {
+		return nil, err
+	}
+
+	names := []string{}
+	payload := SbomPayload{}
+	resp, err := s.githubClient.Do(s.ctx, req, &payload)
+	if err != nil {
+		if resp.StatusCode == 404 {
+			return nil, dependenciesNotFoundError
+		}
+		return nil, err
+	}
+
+	godepRegex := regexp.MustCompile("go:github.com/giantswarm/([^/]+).*")
+	actionRegex := regexp.MustCompile("actions:giantswarm/([^/]+).*")
+
+	for _, item := range payload.Sbom.Packages {
+		// We only want either of these:
+		// 'go:github.com/giantswarm/NAME'
+		// 'actions:giantswarm/NAME'
+		matches := godepRegex.FindStringSubmatch(item.Name)
+		if len(matches) > 0 {
+			names = append(names, matches[1])
+		}
+
+		matches = actionRegex.FindStringSubmatch(item.Name)
+		if len(matches) > 0 {
+			names = append(names, matches[1])
+		}
+	}
+
+	return names, nil
+}

--- a/pkg/repositories/errors.go
+++ b/pkg/repositories/errors.go
@@ -9,3 +9,8 @@ var invalidConfigError = &microerror.Error{
 var repositoryNotFoundError = &microerror.Error{
 	Kind: "repositoryNotFoundError",
 }
+
+var dependenciesNotFoundError = &microerror.Error{
+	Kind: "dependenciesNotFoundError",
+	Desc: "Please enable the dependency graph feature for this repository",
+}

--- a/pkg/repositories/repositories.go
+++ b/pkg/repositories/repositories.go
@@ -49,6 +49,9 @@ type GithubRepoDetails struct {
 
 	// Whether the repository is private. If false, it's public.
 	IsPrivate bool
+
+	// The main programming language in the repo.
+	MainLanguage string
 }
 
 // A struct for caching repository content information.
@@ -132,6 +135,7 @@ func (s *Service) loadGithubRepoDetails() error {
 				Description:   repo.GetDescription(),
 				IsPrivate:     repo.GetPrivate(),
 				DefaultBranch: repo.GetDefaultBranch(),
+				MainLanguage:  strings.ToLower(repo.GetLanguage()),
 			}
 		}
 
@@ -236,6 +240,16 @@ func (s *Service) MustGetDescription(name string) string {
 	}
 
 	return s.githubRepoDetails[name].Description
+}
+
+// Returns the main language for the given repo. If not available,
+// or an error occurs, returns an empty string.
+func (s *Service) MustGetLanguage(name string) string {
+	if _, ok := s.githubRepoDetails[name]; !ok {
+		return ""
+	}
+
+	return s.githubRepoDetails[name].MainLanguage
 }
 
 // Returns the public/private info for the given repo.


### PR DESCRIPTION
### What does this PR do?

This PR adds code to query the Github dependency graph and export the acquired dependency information as a `dependsOn` relation between components.

### What is the effect of this change to users?

Components are listed as dependencies in the developer portal catalog.

### How does it look like?

<!-- Please add anything that represents the change visually. Screenshots, output, logs, ... -->

### Any background context you can provide?

https://github.com/giantswarm/giantswarm/issues/27854

### What is needed from the reviewers?

### Do the docs need to be updated?

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
