### PR TITLE
Add dashboard link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- For components of type "service", we add a Grafana dashboard link.
+
 ### Removed
 
 - Removed debug logging on dependencies found.

--- a/pkg/catalog/functions.go
+++ b/pkg/catalog/functions.go
@@ -71,6 +71,18 @@ func CreateComponentEntity(r repositories.Repo, team, description string, isPriv
 		e.Metadata.Tags = append(e.Metadata.Tags, fmt.Sprintf("flavor:%s", flavor))
 	}
 
+	if r.ComponentType == "service" {
+		// Add Grafana dashboard links
+		e.Metadata.Links = []EntityLink{
+			{
+				URL:   fmt.Sprintf("https://giantswarm.grafana.net/d/eb617ba1-209a-4d57-9963-1af9a8ddc8d4/general-service-metrics?orgId=1&var-app=%s&from=now-24h&to=now", r.Name),
+				Title: "General service metrics dashboard",
+				Icon:  "dashboard",
+				Type:  "grafana-dashboard",
+			},
+		}
+	}
+
 	return e
 }
 


### PR DESCRIPTION
### What does this PR do?

For every component entity of type "service", this change adds a dashboard link to this dashboard:

[General service metrics](https://giantswarm.grafana.net/d/eb617ba1-209a-4d57-9963-1af9a8ddc8d4/general-service-metrics?orgId=1&var-app=loki)

with the service selected.

### What is the effect of this change to users?

The dashboard link will be displayed in the entity details view in the dashboard.

### Any background context you can provide?

[<!-- Please link public issues or summarize if not public. -->](https://github.com/giantswarm/giantswarm/issues/27919)

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
