### PR TITLE
Add grafana dashboard selector to group entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add `grafana/dashboard-selector` annotaion to Group entities, to enable showing of dashboards for teams.
+
 ## [0.2.1] - 2023-08-18
+
+- Ensure deterministic order of dependencies, avoid duplicates.
+- Simplify Github dependency graph query.
 
 ## [0.2.0] - 2023-08-17
 

--- a/pkg/catalog/functions.go
+++ b/pkg/catalog/functions.go
@@ -94,6 +94,9 @@ func CreateGroupEntity(name, displayName, description, parent string, members []
 		Kind:       EntityKindGroup,
 		Metadata: EntityMetadata{
 			Name: name,
+			Annotations: map[string]string{
+				"grafana/dashboard-selector": "tags @> 'owner:team-atlas'",
+			},
 		},
 	}
 	spec := GroupSpec{


### PR DESCRIPTION
### What does this PR do?

Adds the annotation `grafana/dashboard-selector: tags @> 'owner:TEAMNAME'` to each Group entity.

This enables showing dashboards for teams in the portal.

### Any background context you can provide?

[<!-- Please link public issues or summarize if not public. -->](https://github.com/giantswarm/giantswarm/issues/27935)

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
