### PR TITLE
Switch from UnmarshalStrict to Unmarshal

### DIFF
--- a/pkg/repositories/repositories.go
+++ b/pkg/repositories/repositories.go
@@ -188,7 +188,7 @@ func (s *Service) loadList(path string) ([]Repo, error) {
 
 func (s *Service) loadListFromBytes(data []byte) ([]Repo, error) {
 	repos := []Repo{}
-	err := yaml.UnmarshalStrict(data, &repos)
+	err := yaml.Unmarshal(data, &repos)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### What does this PR do?

In preparation for [updating module gopkg.in/yaml.v2 to v3](https://github.com/giantswarm/backstage-catalog-importer/pull/41), this PR replaces a use of `UnmarshalStrict` with `Unmarshal`. The strict behaviour was not needed in this case (importing repositories YAML data) as any unknown fields are simply ignored anyway. `UnmarshalStrict` is not available in v3.

### What is the effect of this change to users?

None

### Should this change be mentioned in the release notes?

No