### PR TITLE
Warn for Go dependencies in use but not covered in the catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add reporting for Go dependencies that are used by other components in the catalog, but not imported into the catalog. This appears in the end of every workflow run log.
+
 ## [0.5.0] - 2023-09-14
 
 - Add OpsGenie related entity annotations.


### PR DESCRIPTION
### What does this PR do?

This PR adds some analysis code and report output. The goal is to identify our Go modules (repositories) that are used some other Go project of ours as dependencies, but itself are not part of the catalog.

The assumption is that these modules, which are not part of the catalog currently, play a role in our production software, so they should be maintained following the same standards as all other production software.

Since backstage-catalog-importer can easily analyse this without the need for extra API calls to GitHub, I decided that I would like to make this part of its routine reporting. So if anyone is 

### What is the effect of this change to users?

If users check the logs for a workflow run, there is now an extra block before the final summary.

### How does it look like?

This issue is an example: https://github.com/giantswarm/giantswarm/issues/28120

### Do the docs need to be updated?

No

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
