### PR TITLE
Split export files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 
 backstage-catalog-importer
 output.yaml
+components.yaml
+groups.yaml
+users.yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Export one file per entity kind instead of one common file.
+
 ### Removed
 
 - Removed `--format` flag and ability to export a Kubernetes ConfigMap.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -256,6 +256,7 @@ func runRoot(cmd *cobra.Command, args []string) {
 	fmt.Printf("\n%d components written to file %s with size %d bytes", numComponents, componentExporter.TargetPath, componentExporter.Len())
 	fmt.Printf("\n%d groups written to file %s with size %d bytes", numGroups, groupExporter.TargetPath, groupExporter.Len())
 	fmt.Printf("\n%d users written to file %s with size %d bytes", numUsers, userExporter.TargetPath, userExporter.Len())
+	fmt.Println("")
 }
 
 // Returns a sorted slice of keys.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,7 +36,7 @@ const (
 )
 
 func init() {
-	rootCmd.PersistentFlags().StringP("output", "o", "output.yaml", "Output file path")
+	rootCmd.PersistentFlags().StringP("output", "o", ".", "Output directory path")
 }
 
 func Execute() {
@@ -80,10 +80,12 @@ func runRoot(cmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 
-	exporter := export.New(export.Config{TargetPath: path})
+	userExporter := export.New(export.Config{TargetPath: path + "/users.yaml"})
+	groupExporter := export.New(export.Config{TargetPath: path + "/groups.yaml"})
+	componentExporter := export.New(export.Config{TargetPath: path + "/components.yaml"})
 
 	numComponents := 0
-	numTeams := 0
+	numGroups := 0
 	numUsers := 0
 
 	// Collect Go dependencies for later analysis
@@ -136,7 +138,7 @@ func runRoot(cmd *cobra.Command, args []string) {
 				deps)
 			numComponents++
 
-			err = exporter.AddEntity(&ent)
+			err = componentExporter.AddEntity(&ent)
 			if err != nil {
 				log.Fatalf("Error: %v", err)
 			}
@@ -181,9 +183,9 @@ func runRoot(cmd *cobra.Command, args []string) {
 			memberNames,
 			team.GetID())
 
-		numTeams++
+		numGroups++
 
-		err = exporter.AddEntity(&entity)
+		err = groupExporter.AddEntity(&entity)
 		if err != nil {
 			log.Fatalf("Error: %v", err)
 		}
@@ -209,7 +211,7 @@ func runRoot(cmd *cobra.Command, args []string) {
 
 		entity := catalog.CreateUserEntity(userSlug, user.GetEmail(), user.GetName(), user.GetBio(), user.GetAvatarURL())
 
-		err = exporter.AddEntity(&entity)
+		err = userExporter.AddEntity(&entity)
 		if err != nil {
 			log.Fatalf("Error: %v", err)
 		}
@@ -217,11 +219,17 @@ func runRoot(cmd *cobra.Command, args []string) {
 		numUsers++
 	}
 
-	size := exporter.Len()
-
-	err = exporter.WriteFile()
+	err = componentExporter.WriteFile()
 	if err != nil {
-		log.Fatalf("Error writing output: %v", err)
+		log.Fatalf("Error writing components: %v", err)
+	}
+	err = groupExporter.WriteFile()
+	if err != nil {
+		log.Fatalf("Error writing groups: %v", err)
+	}
+	err = userExporter.WriteFile()
+	if err != nil {
+		log.Fatalf("Error writing users: %v", err)
 	}
 
 	// Filter Go dependencies to those that are not in the catalog.
@@ -245,8 +253,9 @@ func runRoot(cmd *cobra.Command, args []string) {
 		fmt.Println("")
 	}
 
-	fmt.Printf("\nWrote %d components, %d groups, %d users", numComponents, numTeams, numUsers)
-	fmt.Printf("\nWrote YAML output to %s with %d bytes\n", path, size)
+	fmt.Printf("\n%d components written to file %s with size %d bytes", numComponents, componentExporter.TargetPath, componentExporter.Len())
+	fmt.Printf("\n%d groups written to file %s with size %d bytes", numGroups, groupExporter.TargetPath, groupExporter.Len())
+	fmt.Printf("\n%d users written to file %s with size %d bytes", numUsers, userExporter.TargetPath, userExporter.Len())
 }
 
 // Returns a sorted slice of keys.

--- a/pkg/export/export.go
+++ b/pkg/export/export.go
@@ -13,18 +13,18 @@ import (
 const separator = "---\n"
 
 type Service struct {
-	targetPath string
+	TargetPath string
 	buffer     bytes.Buffer
 }
 
 type Config struct {
-	// Path to folder we'll export all files to.
+	// Path of the file that will be written.
 	TargetPath string
 }
 
 func New(config Config) *Service {
 	s := &Service{
-		targetPath: config.TargetPath,
+		TargetPath: config.TargetPath,
 	}
 
 	_, _ = s.buffer.WriteString("#\n# This file was generated automatically. PLEASE DO NOT MODIFY IT BY HAND!\n#\n\n")
@@ -57,7 +57,7 @@ func (s *Service) Len() int {
 
 // Writes the buffer content to a file.
 func (s *Service) WriteFile() error {
-	file, err := os.Create(s.targetPath)
+	file, err := os.Create(s.TargetPath)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### What does this PR do?

Towards https://github.com/giantswarm/giantswarm/issues/28249

This creates three instead of one output file:

- components.yaml
- groups.yaml
- users.yaml

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
