### PR TITLE
Experiment - Add workflow to report code coverage

### DIFF
--- a/.github/workflows/go-coverage.yaml
+++ b/.github/workflows/go-coverage.yaml
@@ -3,6 +3,7 @@ on:
   pull_request:
   push:
     branches:
+      - test-go-coverage-workflow # TODO: remove before merging
       # It's important that the action also runs on merge to main
       - main
 
@@ -10,13 +11,17 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - name: Clone repository
+      uses: actions/checkout@v4
       with:
         # default fetch-depth is insufficent to find previous coverage notes
         fetch-depth: 10
 
-    - uses: gwatts/go-coverage-action@v1.3.0
+    - name: Create coverage report
+      uses: gwatts/go-coverage-action@v1.3.0
       id: coverage
+      env:
+          GITHUB_TOKEN: "${{ secrets.TAYLORBOT_GITHUB_ACTION }}"
       with:
         # Optional coverage threshold
         # use fail-coverage to determine what should happen below this threshold

--- a/.github/workflows/go-coverage.yaml
+++ b/.github/workflows/go-coverage.yaml
@@ -18,7 +18,7 @@ jobs:
         fetch-depth: 10
 
     - name: Create coverage report
-      uses: gwatts/go-coverage-action@v1.3.0
+      uses: gwatts/go-coverage-action@cf5795fd4027fa3163339b4c284ab50532e65d11 #v1.3.0
       id: coverage
       env:
           GITHUB_TOKEN: "${{ secrets.TAYLORBOT_GITHUB_ACTION }}"

--- a/.github/workflows/go-coverage.yaml
+++ b/.github/workflows/go-coverage.yaml
@@ -1,0 +1,42 @@
+name: "Go coverage report"
+on:
+  pull_request:
+  push:
+    branches:
+      # It's important that the action also runs on merge to main
+      - main
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        # default fetch-depth is insufficent to find previous coverage notes
+        fetch-depth: 10
+
+    - uses: gwatts/go-coverage-action@v1.3.0
+      id: coverage
+      with:
+        # Optional coverage threshold
+        # use fail-coverage to determine what should happen below this threshold
+        #coverage-threshold: 80
+        fail-coverage: 1
+
+        # collect coverage for all packages beyond the one under test
+        cover-pkg: ./...
+
+        # Ignore code-generated files when calculating coverage totals
+        #ignore-pattern: |
+        #  \.pb\.go$
+        #  \_string\.go$
+        
+        # A url that the html report will be accessible at, once your
+        # workflow uploads it.  Used in the pull request comment.
+    #    report-url: https://artifacts.example.com/go-coverage/${{ github.ref_name}}.html
+
+    #- name: Upload coverage to s3
+    #  # ensure this runs regardless of whether the threshold is met using always()
+    #  if: always() && steps.coverage.outputs.report-pathname != ''
+    #  run: |
+    #    aws s3 cp ${{ steps.coverage.outputs.report-pathname }} s3://artifacts.example.com-bucket/go-coverage/${{ github.ref_name}}.html

--- a/pkg/export/export_test.go
+++ b/pkg/export/export_test.go
@@ -1,6 +1,7 @@
 package export
 
 import (
+	"bytes"
 	"flag"
 	"io"
 	"os"
@@ -119,4 +120,37 @@ func goldenValue(t *testing.T, goldenFile string, actual string, update bool) st
 		t.Fatalf("Error opening file %s: %s", goldenPath, err)
 	}
 	return string(content)
+}
+
+func TestService_Len(t *testing.T) {
+	nonEmpty := bytes.Buffer{}
+	_, err := nonEmpty.WriteString("123")
+	if err != nil {
+		t.Fatalf("Error creating buffer: %v", err)
+
+	}
+
+	tests := []struct {
+		name    string
+		service *Service
+		want    int
+	}{
+		{
+			name:    "Empty buffer",
+			service: &Service{buffer: bytes.Buffer{}},
+			want:    0,
+		},
+		{
+			name:    "Buffer with length 3",
+			service: &Service{buffer: nonEmpty},
+			want:    3,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.service.Len(); got != tt.want {
+				t.Errorf("Service.Len() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/pkg/export/export_test.go
+++ b/pkg/export/export_test.go
@@ -1,7 +1,6 @@
 package export
 
 import (
-	"bytes"
 	"flag"
 	"io"
 	"os"
@@ -120,37 +119,4 @@ func goldenValue(t *testing.T, goldenFile string, actual string, update bool) st
 		t.Fatalf("Error opening file %s: %s", goldenPath, err)
 	}
 	return string(content)
-}
-
-func TestService_Len(t *testing.T) {
-	nonEmpty := bytes.Buffer{}
-	_, err := nonEmpty.WriteString("123")
-	if err != nil {
-		t.Fatalf("Error creating buffer: %v", err)
-
-	}
-
-	tests := []struct {
-		name    string
-		service *Service
-		want    int
-	}{
-		{
-			name:    "Empty buffer",
-			service: &Service{buffer: bytes.Buffer{}},
-			want:    0,
-		},
-		{
-			name:    "Buffer with length 3",
-			service: &Service{buffer: nonEmpty},
-			want:    3,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.service.Len(); got != tt.want {
-				t.Errorf("Service.Len() = %v, want %v", got, tt.want)
-			}
-		})
-	}
 }

--- a/pkg/repositories/repositories.go
+++ b/pkg/repositories/repositories.go
@@ -84,7 +84,7 @@ func New(c Config) (*Service, error) {
 		return nil, microerror.Maskf(invalidConfigError, "no Github repository name configured")
 	}
 	if c.GithubAuthToken == "" {
-		return nil, microerror.Maskf(invalidConfigError, "no Github token given")
+		return nil, microerror.Maskf(invalidConfigError, "no Github token given (env variable GITHUB_TOKEN not set)")
 	}
 
 	ts := oauth2.StaticTokenSource(


### PR DESCRIPTION
This PR introduces a workflow that reports code coverage and changes of it in GitHub PR comments.

I'm using this project as an example only. If we like what this action does for us, we should introduce it to more/all Go projects via devctl.

Anyway, I would like to merge this PR, so that we get a coverage baseline on the `main` branch and can see how a test coverage change looks in another PR.