### PR TITLE
Allow repo config to override deployment names for resource discovery

### DIFF
--- a/pkg/export/export_test.go
+++ b/pkg/export/export_test.go
@@ -71,6 +71,47 @@ func TestServiceOutput(t *testing.T) {
 					[]string{"first-dependency", "second-dependency"}),
 			},
 		},
+		{
+			name:       "Component with individual deployment names",
+			goldenFile: "case02.golden",
+			entities: []catalog.Entity{
+				// catalog.CreateGroupEntity(
+				// 	"myorg/team-slug",
+				// 	"team-name",
+				// 	"A simple team with simple people",
+				// 	"area-everything",
+				// 	[]string{"jane-doe", "second-member"},
+				// 	16638849),
+				// catalog.CreateUserEntity(
+				// 	"jane-doe",
+				// 	"jane@acme.org",
+				// 	"Jane Doe",
+				// 	"Experienced DevOps engineer, jack of all trades",
+				// 	"https://avatars.githubusercontent.com/u/12345678?v=4"),
+				catalog.CreateComponentEntity(
+					repositories.Repo{
+						Name:            "project-with-two-apps",
+						ComponentType:   "service",
+						DeploymentNames: []string{"first-name", "second-name-app"},
+						System:          "everything-system",
+						Gen: repositories.RepoGen{
+							Flavors:  []repositories.RepoFlavor{"app", "generic"},
+							Language: "go",
+						},
+						Lifecycle:    "production",
+						Replacements: repositories.RepoReplacements{},
+						AppTestSuite: t,
+					},
+					"myorg/team-slug",
+					"Project that includes two apps",
+					"everything-system",
+					false,
+					true,
+					true,
+					"main",
+					[]string{"first-dependency", "second-dependency"}),
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/export/testdata/case01.golden
+++ b/pkg/export/testdata/case01.golden
@@ -47,17 +47,17 @@ metadata:
         backstage.io/source-location: url:https://github.com/giantswarm/my-service
         backstage.io/techdocs-ref: url:https://github.com/giantswarm/my-service/tree/main
         circleci.com/project-slug: github/giantswarm/my-service
-        giantswarm.io/deployment-names: my-service, my-service-app
+        giantswarm.io/deployment-names: my-service,my-service-app
         github.com/project-slug: giantswarm/my-service
         github.com/team-slug: myorg/team-slug
-        opsgenie.com/component-selector: detailsPair(app:my-service)
+        opsgenie.com/component-selector: detailsPair(app:my-service) OR detailsPair(app:my-service-app)
         opsgenie.com/team: myorg/team-slug
         quay.io/repository-slug: giantswarm/my-service
     tags:
         - language:go
         - flavor:app
     links:
-        - url: https://giantswarm.grafana.net/d/eb617ba1-209a-4d57-9963-1af9a8ddc8d4/general-service-metrics?orgId=1&var-app=my-service&from=now-24h&to=now
+        - url: https://giantswarm.grafana.net/d/eb617ba1-209a-4d57-9963-1af9a8ddc8d4/general-service-metrics?orgId=1&var-app=my-service&var-app=my-service-app&from=now-24h&to=now
           title: General service metrics dashboard
           icon: dashboard
           type: grafana-dashboard

--- a/pkg/export/testdata/case02.golden
+++ b/pkg/export/testdata/case02.golden
@@ -1,0 +1,42 @@
+#
+# This file was generated automatically. PLEASE DO NOT MODIFY IT BY HAND!
+#
+
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+    name: project-with-two-apps
+    description: Project that includes two apps
+    labels:
+        giantswarm.io/flavor-app: "true"
+        giantswarm.io/flavor-generic: "true"
+        giantswarm.io/language: go
+    annotations:
+        backstage.io/kubernetes-id: project-with-two-apps
+        backstage.io/source-location: url:https://github.com/giantswarm/project-with-two-apps
+        backstage.io/techdocs-ref: url:https://github.com/giantswarm/project-with-two-apps/tree/main
+        circleci.com/project-slug: github/giantswarm/project-with-two-apps
+        giantswarm.io/deployment-names: first-name,second-name-app
+        github.com/project-slug: giantswarm/project-with-two-apps
+        github.com/team-slug: myorg/team-slug
+        opsgenie.com/component-selector: detailsPair(app:first-name) OR detailsPair(app:second-name-app)
+        opsgenie.com/team: myorg/team-slug
+        quay.io/repository-slug: giantswarm/project-with-two-apps
+    tags:
+        - language:go
+        - flavor:app
+        - flavor:generic
+    links:
+        - url: https://giantswarm.grafana.net/d/eb617ba1-209a-4d57-9963-1af9a8ddc8d4/general-service-metrics?orgId=1&var-app=first-name&var-app=second-name-app&from=now-24h&to=now
+          title: General service metrics dashboard
+          icon: dashboard
+          type: grafana-dashboard
+spec:
+    type: service
+    lifecycle: production
+    owner: myorg/team-slug
+    system: everything-system
+    dependsOn:
+        - component:first-dependency
+        - component:second-dependency

--- a/pkg/repositories/testdata/team-honeybadger.yaml
+++ b/pkg/repositories/testdata/team-honeybadger.yaml
@@ -297,6 +297,10 @@
   replace:
     architect-orb: false
 - name: happa
+  componentType: service
+  deploymentNames:
+    - happa
+    - fe-docs
   gen:
     flavours:
     - app

--- a/pkg/repositories/types.go
+++ b/pkg/repositories/types.go
@@ -1,13 +1,14 @@
 package repositories
 
 type Repo struct {
-	Name          string           `yaml:"name"`
-	ComponentType string           `yaml:"componentType"`
-	System        string           `yaml:"system"`
-	Gen           RepoGen          `yaml:"gen"`
-	Lifecycle     RepoLifecycle    `yaml:"lifecycle"`
-	Replacements  RepoReplacements `yaml:"replace"`
-	AppTestSuite  interface{}      `yaml:"app_test_suite"`
+	Name            string           `yaml:"name"`
+	ComponentType   string           `yaml:"componentType"`
+	DeploymentNames []string         `yaml:"deploymentNames"`
+	System          string           `yaml:"system"`
+	Gen             RepoGen          `yaml:"gen"`
+	Lifecycle       RepoLifecycle    `yaml:"lifecycle"`
+	Replacements    RepoReplacements `yaml:"replace"`
+	AppTestSuite    interface{}      `yaml:"app_test_suite"`
 }
 
 type RepoFlavor string


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/29857

So far, the name(s) used to find deployments as generated from a repository name (slug). We used `SLUG` and `SLUG-app` to find deployments with and without app suffix. For discovery of OpsGenie alerts and for linking to the service metrics Grafana dashboard, we only used the repo slug.

This PR allows to set the deployment names to look for explicitly. If this is not set, we default to `SLUG` and `SLUG-app`.

Whatever names get set, either explicitly or via the default mechanism, these are now also used for OpsGenie alert lookup and as app selection in the Grafana service metrics dashboard.