### PR TITLE
Add release annotation and tags, add default branch tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add annotations about the latest release of a component entity:
+    - `backstage.giantswarm.io/latest-release-tag`
+    - `backstage.giantswarm.io/latest-release-date`
+- Add tag `no-releases` in case there are no releases for a component
+- Adds tag `defaultbranch:master` if the component repo uses master as the default branch name
+
+### Removed
+
+- Remove `dependabotRemove` key from repositories data processing
+
 ## [0.10.0] - 2024-02-26
 
 ### Added

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -115,6 +115,9 @@ func runRoot(cmd *cobra.Command, args []string) {
 			deps := []string{}
 			lang := repoService.MustGetLanguage(repo.Name)
 
+			latestReleaseTime := repoService.MustGetLatestReleaseTime(repo.Name)
+			latestReleaseTag := repoService.MustGetLatestReleaseTag(repo.Name)
+
 			if lang == "go" {
 				deps, err = repoService.GetDependencies(repo.Name)
 				if err != nil {
@@ -135,6 +138,8 @@ func runRoot(cmd *cobra.Command, args []string) {
 				hasCircleCi,
 				hasReadme,
 				repoService.MustGetDefaultBranch(repo.Name),
+				latestReleaseTime,
+				latestReleaseTag,
 				deps)
 			numComponents++
 

--- a/pkg/export/export_test.go
+++ b/pkg/export/export_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 
@@ -54,10 +55,9 @@ func TestServiceOutput(t *testing.T) {
 						},
 						Lifecycle: "production",
 						Replacements: repositories.RepoReplacements{
-							ArchitectOrb:     true,
-							Renovate:         true,
-							PreCommit:        true,
-							DependabotRemove: true,
+							ArchitectOrb: true,
+							Renovate:     true,
+							PreCommit:    true,
 						},
 						AppTestSuite: t,
 					},
@@ -68,6 +68,8 @@ func TestServiceOutput(t *testing.T) {
 					true,
 					true,
 					"main",
+					time.Time{},
+					"v1.2.3",
 					[]string{"first-dependency", "second-dependency"}),
 			},
 		},
@@ -75,19 +77,6 @@ func TestServiceOutput(t *testing.T) {
 			name:       "Component with individual deployment names",
 			goldenFile: "case02.golden",
 			entities: []catalog.Entity{
-				// catalog.CreateGroupEntity(
-				// 	"myorg/team-slug",
-				// 	"team-name",
-				// 	"A simple team with simple people",
-				// 	"area-everything",
-				// 	[]string{"jane-doe", "second-member"},
-				// 	16638849),
-				// catalog.CreateUserEntity(
-				// 	"jane-doe",
-				// 	"jane@acme.org",
-				// 	"Jane Doe",
-				// 	"Experienced DevOps engineer, jack of all trades",
-				// 	"https://avatars.githubusercontent.com/u/12345678?v=4"),
 				catalog.CreateComponentEntity(
 					repositories.Repo{
 						Name:            "project-with-two-apps",
@@ -108,7 +97,9 @@ func TestServiceOutput(t *testing.T) {
 					false,
 					true,
 					true,
-					"main",
+					"master",
+					time.Time{},
+					"",
 					[]string{"first-dependency", "second-dependency"}),
 			},
 		},

--- a/pkg/export/testdata/case01.golden
+++ b/pkg/export/testdata/case01.golden
@@ -43,6 +43,8 @@ metadata:
         giantswarm.io/flavor-app: "true"
         giantswarm.io/language: go
     annotations:
+        backstage.giantswarm.io/latest-release-date: "0001-01-01T00:00:00Z"
+        backstage.giantswarm.io/latest-release-tag: v1.2.3
         backstage.io/kubernetes-id: my-service
         backstage.io/source-location: url:https://github.com/giantswarm/my-service
         backstage.io/techdocs-ref: url:https://github.com/giantswarm/my-service/tree/main
@@ -54,8 +56,8 @@ metadata:
         opsgenie.com/team: myorg/team-slug
         quay.io/repository-slug: giantswarm/my-service
     tags:
-        - language:go
         - flavor:app
+        - language:go
     links:
         - url: https://giantswarm.grafana.net/d/eb617ba1-209a-4d57-9963-1af9a8ddc8d4/general-service-metrics?orgId=1&var-app=my-service&var-app=my-service-app&from=now-24h&to=now
           title: General service metrics dashboard

--- a/pkg/export/testdata/case02.golden
+++ b/pkg/export/testdata/case02.golden
@@ -15,7 +15,7 @@ metadata:
     annotations:
         backstage.io/kubernetes-id: project-with-two-apps
         backstage.io/source-location: url:https://github.com/giantswarm/project-with-two-apps
-        backstage.io/techdocs-ref: url:https://github.com/giantswarm/project-with-two-apps/tree/main
+        backstage.io/techdocs-ref: url:https://github.com/giantswarm/project-with-two-apps/tree/master
         circleci.com/project-slug: github/giantswarm/project-with-two-apps
         giantswarm.io/deployment-names: first-name,second-name-app
         github.com/project-slug: giantswarm/project-with-two-apps
@@ -24,9 +24,11 @@ metadata:
         opsgenie.com/team: myorg/team-slug
         quay.io/repository-slug: giantswarm/project-with-two-apps
     tags:
-        - language:go
+        - defaultbranch:master
         - flavor:app
         - flavor:generic
+        - language:go
+        - no-releases
     links:
         - url: https://giantswarm.grafana.net/d/eb617ba1-209a-4d57-9963-1af9a8ddc8d4/general-service-metrics?orgId=1&var-app=first-name&var-app=second-name-app&from=now-24h&to=now
           title: General service metrics dashboard

--- a/pkg/repositories/testdata/artificial.yaml
+++ b/pkg/repositories/testdata/artificial.yaml
@@ -20,4 +20,3 @@
     architect-orb: false
     renovate: true
     precommit: true
-    dependabotRemove: false

--- a/pkg/repositories/types.go
+++ b/pkg/repositories/types.go
@@ -1,5 +1,8 @@
 package repositories
 
+import "time"
+
+// Repo represents an entry in the giantswarm/github repositories YAML data.
 type Repo struct {
 	Name            string           `yaml:"name"`
 	ComponentType   string           `yaml:"componentType"`
@@ -35,8 +38,41 @@ type RepoGen struct {
 }
 
 type RepoReplacements struct {
-	ArchitectOrb     bool `yaml:"architect-orb"`
-	Renovate         bool `yaml:"renovate"`
-	PreCommit        bool `yaml:"precommit"`
-	DependabotRemove bool `yaml:"dependabotRemove"`
+	ArchitectOrb bool `yaml:"architect-orb"`
+	Renovate     bool `yaml:"renovate"`
+	PreCommit    bool `yaml:"precommit"`
+}
+
+// A sparse struct for caching just the GitHub
+// repository details we need.
+type GithubRepoDetails struct {
+	// Repository name
+	Name string
+
+	// Repository description
+	Description string
+
+	// Name of the default branch
+	DefaultBranch string
+
+	// Whether the repository is private. If false, it's public.
+	IsPrivate bool
+
+	// The main programming language in the repo.
+	MainLanguage string
+
+	// Creation date/time of the latest release.
+	LatestReleaseTime time.Time
+
+	// Tag name of the latest release.
+	LatestReleaseTag string
+}
+
+// A struct for caching repository content information.
+type GithubRepoContentDetails struct {
+	// Whether the repository has a CircleCI configuration file.
+	HasCircleCI bool
+
+	// Whether the repository has a README.md in the root directory.
+	HasReadme bool
 }


### PR DESCRIPTION
### What does this PR do?

- Adds annotations about the latest release of a component entity:
  - `backstage.giantswarm.io/latest-release-tag`
  - `backstage.giantswarm.io/latest-release-date`
- Adds a tag `no-releases` in case there are no releases for a component
- Adds tag `defaultbranch:master` if the component repo uses `master` as the default branch name
- Removes `dependabotRemove` key from repositories data (cleanup)
- Sort tags alphabetically in output

To fetch information about the latest release, one more API call is made per repository. Like with the similar calls before, this API call is made even if the repository does not end up in the export. There is room for improvement here.

### What is the effect of this change to users?

The new tags tag will be available as a selector to users in the catalog list view.

The plan is to display the new annotation's info in the catalog somewhere.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
