### PR TITLE
Reduce API requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add annotations about the latest release of a component entity:
-    - `backstage.giantswarm.io/latest-release-tag`
-    - `backstage.giantswarm.io/latest-release-date`
+  - `backstage.giantswarm.io/latest-release-tag`
+  - `backstage.giantswarm.io/latest-release-date`
 - Add tag `no-releases` in case there are no releases for a component
 - Adds tag `defaultbranch:master` if the component repo uses master as the default branch name
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -115,8 +115,15 @@ func runRoot(cmd *cobra.Command, args []string) {
 			deps := []string{}
 			lang := repoService.MustGetLanguage(repo.Name)
 
-			latestReleaseTime := repoService.MustGetLatestReleaseTime(repo.Name)
-			latestReleaseTag := repoService.MustGetLatestReleaseTag(repo.Name)
+			latestReleaseTime, err := repoService.MustGetLatestReleaseTime(repo.Name)
+			if err != nil {
+				log.Fatalf("Error: %v", err)
+			}
+
+			latestReleaseTag, err := repoService.MustGetLatestReleaseTag(repo.Name)
+			if err != nil {
+				log.Fatalf("Error: %v", err)
+			}
 
 			if lang == "go" {
 				deps, err = repoService.GetDependencies(repo.Name)

--- a/pkg/repositories/repositories.go
+++ b/pkg/repositories/repositories.go
@@ -105,6 +105,10 @@ func (s *Service) loadGithubRepoDetails() error {
 		}
 
 		for _, repo := range r {
+			if repo.GetArchived() {
+				continue
+			}
+
 			name := repo.GetName()
 			details := GithubRepoDetails{
 				Name:          name,

--- a/pkg/repositories/repositories.go
+++ b/pkg/repositories/repositories.go
@@ -6,7 +6,6 @@ package repositories
 import (
 	"context"
 	b64 "encoding/base64"
-	"fmt"
 	"net/http"
 	"os"
 	"strings"
@@ -47,9 +46,14 @@ type Service struct {
 	githubRepoDetails map[string]GithubRepoDetails
 	// Cached information on repo content
 	githubRepoContentDetails map[string]GithubRepoContentDetails
+	// Cached information on repo releases
+	githubReleaseDetails map[string]GithubReleaseDetails
 }
 
 // New instantiates a new repositories service.
+//
+// This results in the fetching of basic data on all repositories owned by the organization,
+// issuing one request per 100 repositories. Beware of rate limiting!
 func New(c Config) (*Service, error) {
 	if c.GithubOrganization == "" {
 		return nil, microerror.Maskf(invalidConfigError, "no Github organization configured")
@@ -118,16 +122,6 @@ func (s *Service) loadGithubRepoDetails() error {
 				MainLanguage:  strings.ToLower(repo.GetLanguage()),
 			}
 
-			latestRelease, response, err := s.githubClient.Repositories.GetLatestRelease(s.ctx, s.config.GithubOrganization, name)
-			if err != nil {
-				if response.StatusCode != http.StatusNotFound {
-					fmt.Printf("Error getting latest release for %s: %v\n", name, err)
-				}
-			} else {
-				details.LatestReleaseTime = latestRelease.CreatedAt.Time
-				details.LatestReleaseTag = latestRelease.GetTagName()
-			}
-
 			repos[name] = details
 		}
 
@@ -162,6 +156,20 @@ func (s *Service) loadGithubRepoContentDetails(name string) error {
 	}
 
 	s.githubRepoContentDetails[name] = details
+
+	return nil
+}
+
+func (s *Service) loadGithubReleaseDetails(name string) error {
+	latestRelease, response, err := s.githubClient.Repositories.GetLatestRelease(s.ctx, s.config.GithubOrganization, name)
+	if err != nil && response.StatusCode != http.StatusNotFound {
+		return err
+	}
+
+	s.githubReleaseDetails[name] = GithubReleaseDetails{
+		LatestReleaseTime: latestRelease.CreatedAt.Time,
+		LatestReleaseTag:  latestRelease.GetTagName(),
+	}
 
 	return nil
 }
@@ -264,22 +272,28 @@ func (s *Service) MustGetDefaultBranch(name string) string {
 
 // Returns the creation time of the repository's most recent release.
 // If no release was found, returns zero-value time.
-func (s *Service) MustGetLatestReleaseTime(name string) time.Time {
-	if _, ok := s.githubRepoDetails[name]; !ok {
-		return time.Time{}
+func (s *Service) MustGetLatestReleaseTime(name string) (time.Time, error) {
+	if _, ok := s.githubReleaseDetails[name]; !ok {
+		err := s.loadGithubReleaseDetails(name)
+		if err != nil {
+			return time.Time{}, microerror.Mask(err)
+		}
 	}
 
-	return s.githubRepoDetails[name].LatestReleaseTime
+	return s.githubReleaseDetails[name].LatestReleaseTime, nil
 }
 
 // Returns the tag of the repository's most recent release.
 // If no release was found, returns empty string.
-func (s *Service) MustGetLatestReleaseTag(name string) string {
-	if _, ok := s.githubRepoDetails[name]; !ok {
-		return ""
+func (s *Service) MustGetLatestReleaseTag(name string) (string, error) {
+	if _, ok := s.githubReleaseDetails[name]; !ok {
+		err := s.loadGithubReleaseDetails(name)
+		if err != nil {
+			return "string", microerror.Mask(err)
+		}
 	}
 
-	return s.githubRepoDetails[name].LatestReleaseTag
+	return s.githubReleaseDetails[name].LatestReleaseTag, nil
 }
 
 // Returns whether the repo has a CircleCI configuration.

--- a/pkg/repositories/types.go
+++ b/pkg/repositories/types.go
@@ -60,12 +60,6 @@ type GithubRepoDetails struct {
 
 	// The main programming language in the repo.
 	MainLanguage string
-
-	// Creation date/time of the latest release.
-	LatestReleaseTime time.Time
-
-	// Tag name of the latest release.
-	LatestReleaseTag string
 }
 
 // A struct for caching repository content information.
@@ -75,4 +69,13 @@ type GithubRepoContentDetails struct {
 
 	// Whether the repository has a README.md in the root directory.
 	HasReadme bool
+}
+
+// Cache for info on releases of a repo.
+type GithubReleaseDetails struct {
+	// Creation date/time of the latest release.
+	LatestReleaseTime time.Time
+
+	// Tag name of the latest release.
+	LatestReleaseTag string
 }


### PR DESCRIPTION
### What does this PR do?

In https://github.com/giantswarm/backstage-catalog-importer/pull/119 I have introduced an API request that would get executed on every repository, even archived ones. This resulted in these API requests being executed even in unit tests and us hitting Github API rate limits in CI.

This PR modifies the logic to only execute the fetching of release details per repo when needed, just like it was already with other per-repo calls.

In addition, we are now skipping caching of repo details for archived repos.

### What is the effect of this change to users?

None

### Should this change be mentioned in the release notes?

No, this fixes an unreleased problem.
