### PR TITLE
Refactor component creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Introduce new `pkg/catalog/Component` type as an abstraction for a component entity.
+
+### Changed
+
+- Function `pkg/catalog/CreateComponentEntity` is now deprecated. We want to use the new `Component` type and its ToEntity method instead.
+
 ## [0.12.0] - 2024-03-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Function `pkg/catalog/CreateComponentEntity` is now deprecated. We want to use the new `Component` type and its ToEntity method instead.
 
+### Fixed
+
+- Tool name in `--help` output is now correct.
+- The component annotation `giantswarm.io/latest-release-date` is no longer rendered if the value would be `0001-01-01T00:00:00Z`.
+
 ## [0.12.0] - 2024-03-28
 
 ### Added

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,7 +20,7 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "backstage-util",
+	Use:   "backstage-catalog-importer",
 	Short: "Giant Swarm tool to import data into backstage's catalog",
 	Run:   runRoot,
 }

--- a/pkg/catalog/component.go
+++ b/pkg/catalog/component.go
@@ -1,8 +1,92 @@
 package catalog
 
-// ComponentSpec contains the Component standard spec fields.
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Component holds our internal representation of something that we want
+// to export as a Component entity.
+type Component struct {
+	// Component name (required)
+	Name string
+
+	// Owner of the component. Defaults to "unspecified".
+	Owner string
+
+	// Description of the component
+	Description string
+
+	// Name of the GitHub repository of the component, in the form of
+	// "<organization>/<repository>"
+	GithubProjectSlug string
+
+	// Name of the Quay repository of the component, in the form of
+	// "<namespace>/<repository>"
+	QuayRepositorySlug string
+
+	// Name of the GitHub team owning the component
+	// TODO: Specify whether organization name must be prefixed
+	GithubTeamSlug string
+
+	// Name of the OpsGenie team owning the component
+	OpsGenieTeam string
+
+	// OpsGenie lookup query to find alerts and incidents for one component,
+	// similar too 'detailsPair(app:myComponent)'
+	OpsGenieComponentSelector string
+
+	// System that the component belongs to
+	System string
+
+	// If the project has a CircleCI configuration, name of the project
+	CircleCiSlug string
+
+	// If the component type is "service", the 'backstage.io/kubernetes-id' annotation
+	// will be set to this value. If empty, the component name will be used.
+	KubernetesID string
+
+	// Whether the component repository has a README file
+	HasReadme bool
+
+	// Default branch of the component repository
+	DefaultBranch string
+
+	// Time of the latest release of the component
+	LatestReleaseTime time.Time
+
+	// Tag of the latest release of the component
+	LatestReleaseTag string
+
+	// Names to use for Kubernetes resource lookup.
+	DeploymentNames []string
+
+	// Component type. Defaults to "unspecified".
+	Type string
+
+	// Component lifecycle styge. Defaults to "production".
+	Lifecycle string
+
+	// Names of components that this component depends on.
+	DependsOn []string
+
+	Tags []string
+
+	Labels map[string]string
+
+	// Extra annotations that are not covered by the fields above.
+	Annotations map[string]string
+
+	Links []EntityLink
+
+	Spec ComponentSpec
+}
+
+// ComponentSpec contains the spec fields for a component entity in Backstage.
 //
-// See: https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+// See: https://backstage.io/docs/features/software-catalog/descriptor-format/#kind-component
 type ComponentSpec struct {
 	// The type of component. This field is required.
 	Type string `yaml:"type"`
@@ -27,4 +111,119 @@ type ComponentSpec struct {
 
 	// An array of entity references to the components and resources that the component depends on.
 	DependsOn []string `yaml:"dependsOn,omitempty"`
+}
+
+func (c *Component) AddTag(tag string) {
+	c.Tags = append(c.Tags, tag)
+}
+
+func (c *Component) AddLink(link EntityLink) {
+	c.Links = append(c.Links, link)
+}
+
+func (c *Component) SetAnnotation(key, value string) {
+	if c.Annotations == nil {
+		c.Annotations = make(map[string]string)
+	}
+	c.Annotations[key] = value
+}
+
+func (c *Component) SetLabel(key, value string) {
+	if c.Labels == nil {
+		c.Labels = make(map[string]string)
+	}
+	c.Labels[key] = value
+}
+
+// Returns an entity representation of the component.
+func (c *Component) ToEntity() *Entity {
+	sort.Strings(c.Tags)
+
+	e := &Entity{
+		APIVersion: "backstage.io/v1alpha1",
+		Kind:       EntityKindComponent,
+		Metadata: EntityMetadata{
+			Annotations: make(map[string]string),
+			Description: c.Description,
+			Labels:      make(map[string]string),
+			Links:       make([]EntityLink, 0),
+			Name:        c.Name,
+			Tags:        c.Tags,
+		},
+	}
+
+	if c.Annotations != nil {
+		for k, v := range c.Annotations {
+			e.Metadata.Annotations[k] = v
+		}
+	}
+
+	if c.Labels != nil {
+		for k, v := range c.Labels {
+			e.Metadata.Labels[k] = v
+		}
+	}
+
+	if c.Links != nil {
+		e.Metadata.Links = c.Links
+	}
+
+	if c.GithubProjectSlug != "" {
+		e.Metadata.Annotations["github.com/project-slug"] = c.GithubProjectSlug
+		e.Metadata.Annotations["backstage.io/source-location"] = fmt.Sprintf("url:https://github.com/%s", c.GithubProjectSlug)
+		if c.HasReadme && c.DefaultBranch != "" {
+			e.Metadata.Annotations["backstage.io/techdocs-ref"] = fmt.Sprintf("url:https://github.com/%s/tree/%s", c.GithubProjectSlug, c.DefaultBranch)
+		}
+	}
+	if c.QuayRepositorySlug != "" {
+		e.Metadata.Annotations["quay.io/repository-slug"] = c.QuayRepositorySlug
+	}
+	if c.GithubTeamSlug != "" {
+		e.Metadata.Annotations["github.com/team-slug"] = c.GithubTeamSlug
+	}
+	if c.OpsGenieTeam != "" {
+		e.Metadata.Annotations["opsgenie.com/team"] = c.OpsGenieTeam
+	}
+	if c.OpsGenieComponentSelector != "" {
+		e.Metadata.Annotations["opsgenie.com/component-selector"] = c.OpsGenieComponentSelector
+	}
+	if c.LatestReleaseTag != "" {
+		e.Metadata.Annotations["giantswarm.io/latest-release-tag"] = c.LatestReleaseTag
+	}
+	if c.LatestReleaseTime.Format(time.RFC3339) != "0001-01-01T00:00:00Z" {
+		e.Metadata.Annotations["giantswarm.io/latest-release-date"] = c.LatestReleaseTime.Format(time.RFC3339)
+	}
+	if c.CircleCiSlug != "" {
+		e.Metadata.Annotations["circleci.com/project-slug"] = c.CircleCiSlug
+	}
+	if c.DeploymentNames != nil {
+		sort.Strings(c.DeploymentNames)
+		e.Metadata.Annotations["giantswarm.io/deployment-names"] = strings.Join(c.DeploymentNames, ",")
+	}
+	if c.Type == "service" {
+		e.Metadata.Annotations["backstage.io/kubernetes-id"] = c.Name
+		if c.KubernetesID != "" {
+			e.Metadata.Annotations["backstage.io/kubernetes-id"] = c.KubernetesID
+		}
+	}
+
+	spec := ComponentSpec{
+		Type:      c.Type,
+		Lifecycle: c.Lifecycle,
+		Owner:     c.Owner,
+	}
+	if c.System != "" {
+		spec.System = c.System
+	}
+	if len(c.DependsOn) > 0 {
+		sort.Strings(c.DependsOn)
+		for i, d := range c.DependsOn {
+			c.DependsOn[i] = "component:" + d
+		}
+		spec.DependsOn = c.DependsOn
+	}
+
+	e.Spec = spec
+
+	return e
 }

--- a/pkg/catalog/component_options.go
+++ b/pkg/catalog/component_options.go
@@ -1,0 +1,148 @@
+package catalog
+
+import (
+	"fmt"
+	"time"
+)
+
+// Option is an option to configure a Component.
+type Option func(*Component)
+
+func NewComponent(name string, options ...Option) (*Component, error) {
+	if name == "" {
+		return nil, fmt.Errorf("name must not be empty")
+	}
+
+	c := &Component{
+		Name:      name,
+		Type:      "unspecified",
+		Owner:     "unspecified",
+		Lifecycle: "production",
+	}
+
+	for _, option := range options {
+		option(c)
+	}
+
+	return c, nil
+}
+
+func WithDescription(description string) Option {
+	return func(c *Component) {
+		c.Description = description
+	}
+}
+
+func WithGithubTeamSlug(team string) Option {
+	return func(c *Component) {
+		c.GithubTeamSlug = team
+	}
+}
+
+func WithSystem(system string) Option {
+	return func(c *Component) {
+		c.System = system
+	}
+}
+
+func WithCircleCiSlug(slug string) Option {
+	return func(c *Component) {
+		c.CircleCiSlug = slug
+	}
+}
+
+func WithHasReadme(hasReadme bool) Option {
+	return func(c *Component) {
+		c.HasReadme = hasReadme
+	}
+}
+
+func WithDefaultBranch(defaultBranch string) Option {
+	return func(c *Component) {
+		c.DefaultBranch = defaultBranch
+	}
+}
+
+func WithLatestReleaseTime(latestReleaseTime time.Time) Option {
+	return func(c *Component) {
+		c.LatestReleaseTime = latestReleaseTime
+	}
+}
+
+func WithLatestReleaseTag(latestReleaseTag string) Option {
+	return func(c *Component) {
+		c.LatestReleaseTag = latestReleaseTag
+	}
+}
+
+func WithOpsGenieTeam(team string) Option {
+	return func(c *Component) {
+		c.OpsGenieTeam = team
+	}
+}
+
+func WithGithubProjectSlug(slug string) Option {
+	return func(c *Component) {
+		c.GithubProjectSlug = slug
+	}
+}
+
+func WithQuayRepositorySlug(slug string) Option {
+	return func(c *Component) {
+		c.QuayRepositorySlug = slug
+	}
+}
+
+func WithDeploymentNames(names ...string) Option {
+	return func(c *Component) {
+		c.DeploymentNames = names
+	}
+}
+
+func WithType(t string) Option {
+	return func(c *Component) {
+		c.Type = t
+	}
+}
+
+func WithLifecycle(lifecycle string) Option {
+	return func(c *Component) {
+		c.Lifecycle = lifecycle
+	}
+}
+
+func WithOpsGenieComponentSelector(selector string) Option {
+	return func(c *Component) {
+		c.OpsGenieComponentSelector = selector
+	}
+}
+
+func WithDependsOn(dependsOn ...string) Option {
+	return func(c *Component) {
+		c.DependsOn = dependsOn
+	}
+}
+
+func WithTags(tags ...string) Option {
+	return func(c *Component) {
+		c.Tags = tags
+	}
+}
+
+func WithLabels(labels map[string]string) Option {
+	return func(c *Component) {
+		c.Labels = labels
+	}
+}
+
+func WithKubernetesID(id string) Option {
+	return func(c *Component) {
+		c.KubernetesID = id
+	}
+}
+
+func WithOwner(owner string) Option {
+	return func(c *Component) {
+		c.Owner = owner
+	}
+}

--- a/pkg/catalog/functions.go
+++ b/pkg/catalog/functions.go
@@ -2,6 +2,7 @@ package catalog
 
 import (
 	"fmt"
+	"log"
 	"sort"
 	"strings"
 	"time"
@@ -10,6 +11,10 @@ import (
 	"github.com/giantswarm/backstage-catalog-importer/pkg/repositories"
 )
 
+// CreateComponentEntity is the deprecated way of generating a component entity.
+// It sets some vaules in a Giant Swarm specific way. We are replacing it, with
+// the goal to make this tool useful for more than just Giant Swarm.
+// Deprecated: Use the Component struct and its ToEntity() method instead.
 func CreateComponentEntity(r repositories.Repo,
 	team string,
 	description string,
@@ -22,151 +27,108 @@ func CreateComponentEntity(r repositories.Repo,
 	latestReleaseTag string,
 	charts []*helmchart.Chart,
 	dependsOn []string) Entity {
-	e := Entity{
-		APIVersion: "backstage.io/v1alpha1",
-		Kind:       EntityKindComponent,
-		Metadata: EntityMetadata{
-			Name:        r.Name,
-			Labels:      map[string]string{},
-			Description: description,
-			Annotations: map[string]string{
-				"github.com/project-slug":      fmt.Sprintf("giantswarm/%s", r.Name),
-				"github.com/team-slug":         team,
-				"backstage.io/source-location": fmt.Sprintf("url:https://github.com/giantswarm/%s", r.Name),
-				"quay.io/repository-slug":      fmt.Sprintf("giantswarm/%s", r.Name),
 
-				// Like team name, but without "team-" prefix
-				"opsgenie.com/team": strings.TrimPrefix(team, "team-"),
-			},
-			Tags: []string{},
-		},
+	// Possible deployment names for resource discovery via the Giant Swarm plugin,
+	// Grafana dashboards, and OpsGenie alerts.
+	deploymentNames := r.DeploymentNames
+
+	// Default deployment names are REPONAME and REPONAME-app.
+	if len(deploymentNames) == 0 {
+		name := strings.TrimSuffix(r.Name, "-app")
+		nameWithAppSuffix := fmt.Sprintf("%s-app", name)
+		deploymentNames = []string{
+			name,
+			nameWithAppSuffix,
+		}
+	}
+
+	// OpsGenie query
+	opsGenieQueryParts := []string{}
+	for _, d := range deploymentNames {
+		opsGenieQueryParts = append(opsGenieQueryParts, fmt.Sprintf("detailsPair(app:%s)", d))
+	}
+	opsGenieQuery := strings.Join(opsGenieQueryParts, " OR ")
+
+	c, err := NewComponent(r.Name,
+		WithDescription(description),
+		WithGithubProjectSlug(fmt.Sprintf("giantswarm/%s", r.Name)),
+		WithGithubTeamSlug(team),
+		WithOpsGenieTeam(strings.TrimPrefix(team, "team-")),
+		WithQuayRepositorySlug(fmt.Sprintf("giantswarm/%s", r.Name)),
+		WithLatestReleaseTag(latestReleaseTag),
+		WithLatestReleaseTime(latestReleaseTime),
+		WithCircleCiSlug(fmt.Sprintf("github/giantswarm/%s", r.Name)),
+		WithDefaultBranch(defaultBranch),
+		WithHasReadme(hasReadme),
+		WithDeploymentNames(deploymentNames...),
+		WithOpsGenieComponentSelector(opsGenieQuery),
+		WithSystem(system),
+		WithType(r.ComponentType),
+		WithOwner(team),
+		WithDependsOn(dependsOn...),
+	)
+	if err != nil {
+		log.Fatalf("Could not create component: %s", err)
 	}
 
 	// Additional metadata
-	{
-		if latestReleaseTag != "" {
-			e.Metadata.Annotations["giantswarm.io/latest-release-tag"] = latestReleaseTag
-			e.Metadata.Annotations["giantswarm.io/latest-release-date"] = latestReleaseTime.Format(time.RFC3339)
+
+	if r.Gen.Language != "" && r.Gen.Language != repositories.RepoLanguageGeneric {
+		c.SetLabel("giantswarm.io/language", string(r.Gen.Language))
+		c.AddTag(fmt.Sprintf("language:%s", r.Gen.Language))
+	}
+
+	if isPrivate {
+		c.AddTag("private")
+	}
+
+	if defaultBranch == "master" {
+		c.AddTag("defaultbranch:master")
+	}
+
+	if latestReleaseTag == "" {
+		c.AddTag("no-releases")
+	}
+
+	if len(charts) > 0 {
+		c.AddTag("helmchart")
+
+		names := []string{}
+		versions := []string{}
+		appVersions := []string{}
+		for _, c := range charts {
+			names = append(names, c.Metadata.Name)
+			versions = append(versions, c.Metadata.Version)
+			appVersions = append(appVersions, c.Metadata.AppVersion)
 		}
 
-		if hasCircleCi {
-			e.Metadata.Annotations["circleci.com/project-slug"] = fmt.Sprintf("github/giantswarm/%s", r.Name)
-		}
+		c.SetAnnotation("giantswarm.io/helmcharts", strings.Join(names, ","))
+		c.SetAnnotation("giantswarm.io/helmchart-versions", strings.Join(versions, ","))
+		c.SetAnnotation("giantswarm.io/helmchart-app-versions", strings.Join(appVersions, ","))
+	}
 
-		if hasReadme && defaultBranch != "" {
-			e.Metadata.Annotations["backstage.io/techdocs-ref"] = fmt.Sprintf("url:https://github.com/giantswarm/%s/tree/%s", r.Name, defaultBranch)
-		}
+	for _, flavor := range r.Gen.Flavors {
+		c.SetLabel(fmt.Sprintf("giantswarm.io/flavor-%s", flavor), "true")
+		c.AddTag(fmt.Sprintf("flavor:%s", flavor))
+	}
 
-		// Possible deployment names for resource discovery via the Giant Swarm plugin,
-		// Grafana dashboards, and OpsGenie alerts.
-		deploymentNames := r.DeploymentNames
-		sort.Strings(deploymentNames)
-
-		// Default deployment names are REPONAME and REPONAME-app.
-		if len(deploymentNames) == 0 {
-			name := strings.TrimSuffix(r.Name, "-app")
-			nameWithAppSuffix := fmt.Sprintf("%s-app", name)
-			deploymentNames = []string{
-				name,
-				nameWithAppSuffix,
-			}
-		}
-
-		e.Metadata.Annotations["giantswarm.io/deployment-names"] = strings.Join(deploymentNames, ",")
-
-		// OpsGenie query
-		queryParts := []string{}
+	// Grafana dashboard link
+	if r.ComponentType == "service" {
+		urlParts := []string{}
 		for _, d := range deploymentNames {
-			queryParts = append(queryParts, fmt.Sprintf("detailsPair(app:%s)", d))
+			urlParts = append(urlParts, fmt.Sprintf("var-app=%s", d))
 		}
-		e.Metadata.Annotations["opsgenie.com/component-selector"] = strings.Join(queryParts, " OR ")
-
-		if r.Gen.Language != "" && r.Gen.Language != repositories.RepoLanguageGeneric {
-			e.Metadata.Labels["giantswarm.io/language"] = string(r.Gen.Language)
-			e.Metadata.Tags = append(e.Metadata.Tags, fmt.Sprintf("language:%s", r.Gen.Language))
-		}
-
-		if isPrivate {
-			e.Metadata.Tags = append(e.Metadata.Tags, "private")
-		}
-
-		if defaultBranch == "master" {
-			e.Metadata.Tags = append(e.Metadata.Tags, "defaultbranch:master")
-		}
-
-		if latestReleaseTag == "" {
-			e.Metadata.Tags = append(e.Metadata.Tags, "no-releases")
-		}
-
-		if len(charts) > 0 {
-			e.Metadata.Tags = append(e.Metadata.Tags, "helmchart")
-			names := []string{}
-			versions := []string{}
-			appVersions := []string{}
-			for _, c := range charts {
-				names = append(names, c.Metadata.Name)
-				versions = append(versions, c.Metadata.Version)
-				appVersions = append(appVersions, c.Metadata.AppVersion)
-			}
-
-			e.Metadata.Annotations["giantswarm.io/helmcharts"] = strings.Join(names, ",")
-			e.Metadata.Annotations["giantswarm.io/helmchart-versions"] = strings.Join(versions, ",")
-			e.Metadata.Annotations["giantswarm.io/helmchart-app-versions"] = strings.Join(appVersions, ",")
-		}
-
-		for _, flavor := range r.Gen.Flavors {
-			e.Metadata.Labels[fmt.Sprintf("giantswarm.io/flavor-%s", flavor)] = "true"
-			e.Metadata.Tags = append(e.Metadata.Tags, fmt.Sprintf("flavor:%s", flavor))
-		}
-
-		sort.Strings(e.Metadata.Tags)
-
-		if r.ComponentType == "service" {
-			// Kubernetes plugin annotation
-			e.Metadata.Annotations["backstage.io/kubernetes-id"] = r.Name
-
-			// Grafana dashboard links
-			urlParts := []string{}
-			for _, d := range deploymentNames {
-				urlParts = append(urlParts, fmt.Sprintf("var-app=%s", d))
-			}
-			e.Metadata.Links = []EntityLink{
-				{
-					URL:   fmt.Sprintf("https://giantswarm.grafana.net/d/eb617ba1-209a-4d57-9963-1af9a8ddc8d4/general-service-metrics?orgId=1&%s&from=now-24h&to=now", strings.Join(urlParts, "&")),
-					Title: "General service metrics dashboard",
-					Icon:  "dashboard",
-					Type:  "grafana-dashboard",
-				},
-			}
-		}
+		c.AddLink(EntityLink{
+			URL:   fmt.Sprintf("https://giantswarm.grafana.net/d/eb617ba1-209a-4d57-9963-1af9a8ddc8d4/general-service-metrics?orgId=1&%s&from=now-24h&to=now", strings.Join(urlParts, "&")),
+			Title: "General service metrics dashboard",
+			Icon:  "dashboard",
+			Type:  "grafana-dashboard",
+		})
 	}
 
-	// Entity spec
+	e := c.ToEntity()
 
-	spec := ComponentSpec{
-		Type:      "unspecified",
-		Lifecycle: "production",
-		Owner:     team,
-		System:    system,
-	}
-
-	if r.ComponentType != "" {
-		spec.Type = r.ComponentType
-	}
-
-	if r.Lifecycle != "production" && r.Lifecycle != "" {
-		spec.Lifecycle = string(r.Lifecycle)
-	}
-
-	if len(dependsOn) > 0 {
-		for _, d := range dependsOn {
-			spec.DependsOn = append(spec.DependsOn, "component:"+d)
-		}
-	}
-
-	e.Spec = spec
-
-	return e
+	return *e
 }
 
 func CreateGroupEntity(name, displayName, description, parent string, members []string, id int64) Entity {

--- a/pkg/export/testdata/case01.golden
+++ b/pkg/export/testdata/case01.golden
@@ -51,7 +51,6 @@ metadata:
         giantswarm.io/helmchart-app-versions: ',2.3.4'
         giantswarm.io/helmchart-versions: 1.2.3,0.4.1
         giantswarm.io/helmcharts: first-chart,second-chart
-        giantswarm.io/latest-release-date: "0001-01-01T00:00:00Z"
         giantswarm.io/latest-release-tag: v1.2.3
         github.com/project-slug: giantswarm/my-service
         github.com/team-slug: myorg/team-slug


### PR DESCRIPTION
### What does this PR do?

Refactors the creation of a component entity, to make it useful not only for the Giant Swarm internal dev portal catalog, but also for creating public catalogs used by customers.

As an aside,

- we are no longer creating the `giantswarm.io/latest-release-date` annotation if the value is `"0001-01-01T00:00:00Z"`.
- the tool name in the `--help` output is fixed

### Any background context you can provide?

Towards https://github.com/giantswarm/roadmap/issues/3291

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
