### PR TITLE
Add group members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Introduce new `pkg/catalog/Component` type as an abstraction for a component entity.
 - Introduce new `pkg/catalog/group/Group` type as an abstraction for a group entity.
 - Add command `appcatalogs` to export Giant Swarm app catalogs.
+- Change groups export for customers to include members, ensure stable sorting.
 
 ### Changed
 

--- a/cmd/appcatalogs.go
+++ b/cmd/appcatalogs.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -147,6 +148,7 @@ func runAppCatalogs(cmd *cobra.Command, args []string) {
 	log.Printf("Wrote file %s", componentExporter.TargetPath)
 
 	log.Printf("Collected %d unique team slugs", len(slugs))
+	slices.Sort(slugs)
 	log.Printf("Team slugs: %s", strings.Join(slugs, " "))
 
 	for _, slug := range slugs {

--- a/cmd/appcatalogs.go
+++ b/cmd/appcatalogs.go
@@ -166,7 +166,16 @@ func runAppCatalogs(cmd *cobra.Command, args []string) {
 			}
 		}
 
-		group, err := groupFromTeam(team)
+		groupMembers, err := teamsService.GetMembers(team.GetSlug())
+		if err != nil {
+			log.Fatalf("ERROR: %v", err)
+		}
+		memberNames := make([]string, len(groupMembers))
+		for i, member := range groupMembers {
+			memberNames[i] = member.GetLogin()
+		}
+
+		group, err := groupFromTeam(team, memberNames)
 		if err != nil {
 			log.Fatalf("ERROR: %v", err)
 		}
@@ -185,12 +194,13 @@ func runAppCatalogs(cmd *cobra.Command, args []string) {
 	log.Printf("Wrote file %s", groupExporter.TargetPath)
 }
 
-func groupFromTeam(team *github.Team) (*group.Group, error) {
+func groupFromTeam(team *github.Team, members []string) (*group.Group, error) {
 	return group.NewGroup(team.GetSlug(),
 		group.WithNamespace("giantswarm"),
 		group.WithDescription(team.GetDescription()),
 		group.WithTitle(team.GetName()),
 		group.WithPictureURL(fmt.Sprintf("https://avatars.githubusercontent.com/t/%d?s=116&v=4", team.GetID())),
+		group.WithMemberNames(members...),
 	)
 }
 


### PR DESCRIPTION
### What does this PR do?

- Add members to group exports for customers
- Ensure stable sorting

### How does it look like?

See https://github.com/giantswarm/backstage-catalogs/pull/4

### Any background context you can provide?

https://github.com/giantswarm/roadmap/issues/3291

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
