### PR TITLE
Users export: stable sorting as before, don't export default namespace, fix title and displayName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Ensure stable sorting of `users` output by entity name, to ensure the same sorting as in v0.12.0 and earlier, when exported via the root command.
+- Only export a user's `.metadata.title` if the Title attribute is set. Only export `.spec.profile.displayName` if the DisplayName attribute is set.
+- Do not export the `.metadata.namespace` field for user entities if it is `"default"`.
+
+### Removed
+
 ## [0.13.0] - 2024-06-20
 
 **Breaking:** User catalog export has moved out of the root command.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -81,13 +81,11 @@ func runRoot(cmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 
-	userExporter := export.New(export.Config{TargetPath: path + "/users.yaml"})
 	groupExporter := export.New(export.Config{TargetPath: path + "/groups.yaml"})
 	componentExporter := export.New(export.Config{TargetPath: path + "/components.yaml"})
 
 	numComponents := 0
 	numGroups := 0
-	numUsers := 0
 
 	// Collect Go dependencies for later analysis
 	dependencies := make(map[string][]string)
@@ -189,9 +187,6 @@ func runRoot(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	// Collect user names for User entity creation.
-	userNamesMap := make(map[string]bool, 1)
-
 	// Export teams
 	teams, err := teamsService.GetAll()
 	if err != nil {
@@ -209,7 +204,6 @@ func runRoot(cmd *cobra.Command, args []string) {
 		for _, u := range members {
 			n := u.GetLogin()
 			memberNames = append(memberNames, n)
-			userNamesMap[n] = true
 		}
 
 		parentTeamName := ""
@@ -265,6 +259,5 @@ func runRoot(cmd *cobra.Command, args []string) {
 
 	fmt.Printf("\n%d components written to file %s with size %d bytes", numComponents, componentExporter.TargetPath, componentExporter.Len())
 	fmt.Printf("\n%d groups written to file %s with size %d bytes", numGroups, groupExporter.TargetPath, groupExporter.Len())
-	fmt.Printf("\n%d users written to file %s with size %d bytes", numUsers, userExporter.TargetPath, userExporter.Len())
 	fmt.Println("")
 }

--- a/cmd/users/users.go
+++ b/cmd/users/users.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"log"
 	"os"
+	"sort"
 
 	"github.com/google/go-github/v62/github"
 	"github.com/spf13/cobra"
@@ -82,6 +83,11 @@ func run(cmd *cobra.Command, args []string) error {
 		}
 		opt.Page = resp.NextPage
 	}
+
+	// Sort by user name
+	sort.Slice(allMembers, func(i, j int) bool {
+		return allMembers[i].GetLogin() < allMembers[j].GetLogin()
+	})
 
 	for _, githubUser := range allMembers {
 		detailedUser, _, err := client.Users.Get(ctx, githubUser.GetLogin())

--- a/cmd/users/users.go
+++ b/cmd/users/users.go
@@ -90,7 +90,7 @@ func run(cmd *cobra.Command, args []string) error {
 		}
 
 		user, err := user.New(githubUser.GetLogin(),
-			user.WithTitle(detailedUser.GetName()),
+			user.WithDisplayName(detailedUser.GetName()),
 			user.WithPictureURL(detailedUser.GetAvatarURL()),
 			user.WithDescription(detailedUser.GetBio()),
 		)

--- a/pkg/output/catalog/user/options.go
+++ b/pkg/output/catalog/user/options.go
@@ -18,6 +18,12 @@ func WithDescription(description string) Option {
 	}
 }
 
+func WithDisplayName(displayName string) Option {
+	return func(c *User) {
+		c.DisplayName = displayName
+	}
+}
+
 func WithTitle(title string) Option {
 	return func(c *User) {
 		c.Title = title

--- a/pkg/output/catalog/user/user.go
+++ b/pkg/output/catalog/user/user.go
@@ -8,6 +8,10 @@ import (
 	bscatalog "github.com/giantswarm/backstage-catalog-importer/pkg/output/bscatalog/v1alpha1"
 )
 
+const (
+	defaultNamespace = "default"
+)
+
 // Option is an option to configure a User.
 type Option func(*User)
 
@@ -20,8 +24,12 @@ type User struct {
 	// Namespace, defaults to "default"
 	Namespace string
 
-	// Display title of the user
+	// Generic entity metadata title
+	// (not recomended to use, use DisplayName instead)
 	Title string
+
+	// Display name of the user
+	DisplayName string
 
 	Description string
 	Email       string
@@ -38,7 +46,7 @@ func New(name string, options ...Option) (*User, error) {
 
 	c := &User{
 		Name:      name,
-		Namespace: "default",
+		Namespace: defaultNamespace,
 	}
 
 	for _, option := range options {
@@ -54,7 +62,7 @@ func (c *User) ToEntity() *bscatalog.Entity {
 
 	spec := bscatalog.UserSpec{
 		Profile: bscatalog.UserProfile{
-			DisplayName: c.Title,
+			DisplayName: c.DisplayName,
 			Picture:     c.PictureURL,
 			Email:       c.Email,
 		},
@@ -67,7 +75,6 @@ func (c *User) ToEntity() *bscatalog.Entity {
 		Metadata: bscatalog.EntityMetadata{
 			Name:        c.Name,
 			Description: c.Description,
-			Namespace:   c.Namespace,
 			Title:       c.Title,
 		},
 		Spec: spec,

--- a/pkg/output/catalog/user/user.go
+++ b/pkg/output/catalog/user/user.go
@@ -80,5 +80,9 @@ func (c *User) ToEntity() *bscatalog.Entity {
 		Spec: spec,
 	}
 
+	if c.Namespace != "" && c.Namespace != defaultNamespace {
+		e.Metadata.Namespace = c.Namespace
+	}
+
 	return e
 }

--- a/pkg/output/catalog/user/user_test.go
+++ b/pkg/output/catalog/user/user_test.go
@@ -24,8 +24,7 @@ func TestUser_ToEntity(t *testing.T) {
 				APIVersion: "backstage.io/v1alpha1",
 				Kind:       bscatalog.EntityKindUser,
 				Metadata: bscatalog.EntityMetadata{
-					Name:      "minimal-user",
-					Namespace: "default",
+					Name: "minimal-user",
 				},
 				Spec: bscatalog.UserSpec{},
 			},

--- a/pkg/output/catalog/user/user_test.go
+++ b/pkg/output/catalog/user/user_test.go
@@ -37,6 +37,7 @@ func TestUser_ToEntity(t *testing.T) {
 			options: []Option{
 				WithNamespace("namespace"),
 				WithTitle("Full Fledged"),
+				WithDisplayName("Full Fledged"),
 				WithEmail("mail@example.com"),
 				WithDescription("A full-fledged user"),
 				WithPictureURL("https://example.com/picture.jpg"),


### PR DESCRIPTION
### What does this PR do?

This PR aligns the output of the new `users` command more with the previous output. Commit titles and changelog explain it in more detail.

### Any background context you can provide?

[<!-- Please link public issues or summarize if not public. -->](https://github.com/giantswarm/roadmap/issues/3291)

### Do the docs need to be updated?

No

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
