### PR TITLE
Fix component lifecycle always `production`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a bug where all components had lifecycle `production`.
+
 ### Changed
 
 - Refactoring

--- a/pkg/output/legacy/create-component-entity.go
+++ b/pkg/output/legacy/create-component-entity.go
@@ -68,6 +68,7 @@ func CreateComponentEntity(r repositories.Repo,
 		component.WithType(r.ComponentType),
 		component.WithOwner(team),
 		component.WithDependsOn(dependsOn...),
+		component.WithLifecycle(string(r.Lifecycle)),
 	)
 	if err != nil {
 		log.Fatalf("Could not create component: %s", err)


### PR DESCRIPTION
### What does this PR do?

This fixes a problem in the component export (root command) where the lifecycle of components would always be `production` regardless of the repo settings.

When changing the inner working of the legacy.CreateComponentEntity function, I missed that one.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
