### PR TITLE
Prevent setting component lifecycle to an empty value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Prevent setting component lifecycle to an empty value.
+
 ## [0.13.2] - 2024-06-21
 
 ### Fixed

--- a/pkg/output/catalog/component/options.go
+++ b/pkg/output/catalog/component/options.go
@@ -99,7 +99,9 @@ func WithType(t string) Option {
 
 func WithLifecycle(lifecycle string) Option {
 	return func(c *Component) {
-		c.Lifecycle = lifecycle
+		if lifecycle != "" {
+			c.Lifecycle = lifecycle
+		}
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

Avoid components with lifecycle other than "deprecated" getting an empty value, as that would be invalid and rejected by Backstage.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
