### PR TITLE
Ensure stable sorting of exported entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add deployment names to customer component entities.
 
+### Changed
+
+- Make sure that exported entities are always sorted by API version, kind, namespace, and name.
+
 ## [0.13.3] - 2024-06-24
 
 ### Fixed

--- a/pkg/output/export/export.go
+++ b/pkg/output/export/export.go
@@ -3,9 +3,11 @@ package export
 
 import (
 	"bytes"
+	"cmp"
 	"os"
+	"slices"
 
-	"gopkg.in/yaml.v3"
+	yaml "gopkg.in/yaml.v3"
 
 	bscatalog "github.com/giantswarm/backstage-catalog-importer/pkg/output/bscatalog/v1alpha1"
 )
@@ -14,6 +16,8 @@ const separator = "---\n"
 
 type Service struct {
 	TargetPath string
+
+	collection []*bscatalog.Entity
 	buffer     bytes.Buffer
 }
 
@@ -22,36 +26,59 @@ type Config struct {
 	TargetPath string
 }
 
+// New returns a new export service.
+// It is used to collect entities, sort them, and write them to a file.
+// For testing convenience, the collection content is stored in a buffer.
+// The entity sort order is: APIVersion, Kind, Metadata.Namespace, Metadata.Name.
 func New(config Config) *Service {
 	s := &Service{
 		TargetPath: config.TargetPath,
 	}
 
+	return s
+}
+
+func (s *Service) updateBuffer() error {
+	s.buffer.Reset()
 	_, _ = s.buffer.WriteString("#\n# This file was generated automatically. PLEASE DO NOT MODIFY IT BY HAND!\n#\n\n")
 
-	return s
+	for i := range s.collection {
+		yamlBytes, err := yaml.Marshal(&s.collection[i])
+		if err != nil {
+			return err
+		}
+		_, err = s.buffer.WriteString(separator)
+		if err != nil {
+			return err
+		}
+		_, err = s.buffer.Write(yamlBytes)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // Adds an entity to the export buffer
 func (s *Service) AddEntity(entity *bscatalog.Entity) error {
-	yamlBytes, err := yaml.Marshal(&entity)
-	if err != nil {
-		return err
-	}
-	_, err = s.buffer.WriteString(separator)
-	if err != nil {
-		return err
-	}
-	_, err = s.buffer.Write(yamlBytes)
-	if err != nil {
-		return err
-	}
+	s.collection = append(s.collection, entity)
+
+	slices.SortFunc(s.collection, func(a, b *bscatalog.Entity) int {
+		return cmp.Or(
+			cmp.Compare(a.APIVersion, b.APIVersion),
+			cmp.Compare(a.Kind, b.Kind),
+			cmp.Compare(a.Metadata.Namespace, b.Metadata.Namespace),
+			cmp.Compare(a.Metadata.Name, b.Metadata.Name),
+		)
+	})
 
 	return nil
 }
 
 // Returns the current length of the buffer.
 func (s *Service) Len() int {
+	_ = s.updateBuffer()
 	return s.buffer.Len()
 }
 
@@ -63,6 +90,11 @@ func (s *Service) WriteFile() error {
 	}
 	defer file.Close()
 
+	err = s.updateBuffer()
+	if err != nil {
+		return err
+	}
+
 	_, err = file.WriteString(s.buffer.String())
 	if err != nil {
 		return err
@@ -71,5 +103,6 @@ func (s *Service) WriteFile() error {
 }
 
 func (s *Service) String() string {
+	_ = s.updateBuffer()
 	return s.buffer.String()
 }

--- a/pkg/output/export/testdata/case01.golden
+++ b/pkg/output/export/testdata/case01.golden
@@ -4,37 +4,6 @@
 
 ---
 apiVersion: backstage.io/v1alpha1
-kind: Group
-metadata:
-    name: myorg/team-slug
-    description: A simple team with simple people
-    annotations:
-        grafana/dashboard-selector: tags @> 'owner:myorg/team-slug'
-        opsgenie.com/team: myorg/team-slug
-spec:
-    type: team
-    profile:
-        displayName: team-name
-        picture: https://avatars.githubusercontent.com/t/16638849?s=116&v=4
-    children: []
-    parent: area-everything
-    members:
-        - jane-doe
-        - second-member
----
-apiVersion: backstage.io/v1alpha1
-kind: User
-metadata:
-    name: jane-doe
-    description: Experienced DevOps engineer, jack of all trades
-spec:
-    profile:
-        displayName: Jane Doe
-        email: jane@acme.org
-        picture: https://avatars.githubusercontent.com/u/12345678?v=4
-    memberOf: []
----
-apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
     name: my-service
@@ -74,3 +43,34 @@ spec:
     dependsOn:
         - component:first-dependency
         - component:second-dependency
+---
+apiVersion: backstage.io/v1alpha1
+kind: Group
+metadata:
+    name: myorg/team-slug
+    description: A simple team with simple people
+    annotations:
+        grafana/dashboard-selector: tags @> 'owner:myorg/team-slug'
+        opsgenie.com/team: myorg/team-slug
+spec:
+    type: team
+    profile:
+        displayName: team-name
+        picture: https://avatars.githubusercontent.com/t/16638849?s=116&v=4
+    children: []
+    parent: area-everything
+    members:
+        - jane-doe
+        - second-member
+---
+apiVersion: backstage.io/v1alpha1
+kind: User
+metadata:
+    name: jane-doe
+    description: Experienced DevOps engineer, jack of all trades
+spec:
+    profile:
+        displayName: Jane Doe
+        email: jane@acme.org
+        picture: https://avatars.githubusercontent.com/u/12345678?v=4
+    memberOf: []


### PR DESCRIPTION
Further improvement on the sorting was necessary, to ensure minimal diffs in pull requests.

Exported entities are now all sorted by:

1. API version
2. Kind
3. Namespace
4. Name