### PR TITLE
Add techdocs-ref annotation to components in customer catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add deployment names to customer component entities.
+- Add techdocs-ref annotation to customer component entities.
 
 ## [0.13.3] - 2024-06-24
 

--- a/cmd/appcatalogs/appcatalogs.go
+++ b/cmd/appcatalogs/appcatalogs.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/go-github/v62/github"
 	"github.com/spf13/cobra"
 
+	"github.com/giantswarm/backstage-catalog-importer/pkg/input/githubrepo"
 	"github.com/giantswarm/backstage-catalog-importer/pkg/input/helmrepoindex"
 	"github.com/giantswarm/backstage-catalog-importer/pkg/input/teams"
 	"github.com/giantswarm/backstage-catalog-importer/pkg/output/catalog/component"
@@ -90,6 +91,11 @@ func runAppCatalogs(cmd *cobra.Command, args []string) {
 	apps := make(map[string]int)
 	teamSlugCount := make(map[string]int)
 
+	repoService, err := githubrepo.New(githubrepo.Config{
+		GithubOrganization: githubOrganization,
+		GithubAuthToken:    token,
+	})
+
 	// Iterate over catalogs
 	for _, url := range urls {
 		fmt.Printf("Reading catalog %s\n", url)
@@ -116,7 +122,7 @@ func runAppCatalogs(cmd *cobra.Command, args []string) {
 
 			apps[appName]++
 
-			component, err := componentFromCatalogEntry(index.Entries[appName][0])
+			component, err := componentFromCatalogEntry(index.Entries[appName][0], repoService)
 			if err != nil {
 				log.Printf("ERROR: Could not create component entity. %v", err)
 				continue
@@ -211,7 +217,7 @@ func groupFromTeam(team *github.Team, members []string) (*group.Group, error) {
 }
 
 // Populates a catalog.Component from an helmrepoindex.Entry
-func componentFromCatalogEntry(entry helmrepoindex.Entry) (*component.Component, error) {
+func componentFromCatalogEntry(entry helmrepoindex.Entry, service *githubrepo.Service) (*component.Component, error) {
 	// owner team
 	team := "group:giantswarm/unspecified"
 	if teamName, ok := entry.Annotations[teamAnnotation]; ok {
@@ -234,6 +240,11 @@ func componentFromCatalogEntry(entry helmrepoindex.Entry) (*component.Component,
 		return nil, fmt.Errorf("could not detect GitHub slug for app %s in app metadata", entry.Name)
 	}
 
+	repoDetails, err := service.GetDetails(entry.Name)
+	if err != nil {
+		return nil, err
+	}
+
 	// deployment names
 	nameWithoutApp := strings.TrimSuffix(entry.Name, "-app")
 	nameWithApp := nameWithoutApp + "-app"
@@ -250,6 +261,7 @@ func componentFromCatalogEntry(entry helmrepoindex.Entry) (*component.Component,
 		component.WithDeploymentNames(nameWithoutApp, nameWithApp),
 		component.WithType("service"),
 		component.WithHasReadme(true), // we assume all apps have a README
+		component.WithDefaultBranch(repoDetails.DefaultBranch),
 	)
 	if err != nil {
 		return nil, err

--- a/cmd/appcatalogs/appcatalogs.go
+++ b/cmd/appcatalogs/appcatalogs.go
@@ -95,6 +95,9 @@ func runAppCatalogs(cmd *cobra.Command, args []string) {
 		GithubOrganization: githubOrganization,
 		GithubAuthToken:    token,
 	})
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	// Iterate over catalogs
 	for _, url := range urls {

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -10,6 +10,7 @@ Our packages can be grouped into two main categories:
 - `input/helmrepoindex` - Provides means to parse Giant Swarm app platform catalogs (which are Helm repository indizes) and read apps from them.
 - `input/teams` - Provides means to read GitHub teams and their members from the GitHub API.
 - `input/helmchart` - Simple helper to parse Helm chart YAML files published by Giant Swarm.
+- `input/githubrepo` - Functions to fetch data about individual Github repositories.
 
 ### Output generation
 

--- a/pkg/input/githubrepo/errors.go
+++ b/pkg/input/githubrepo/errors.go
@@ -1,0 +1,11 @@
+package githubrepo
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+var repositoryNotFoundError = &microerror.Error{
+	Kind: "repositoryNotFoundError",
+}

--- a/pkg/input/githubrepo/githubrepo.go
+++ b/pkg/input/githubrepo/githubrepo.go
@@ -1,0 +1,84 @@
+// Functions to fetch data about / from an individual Github repository.
+package githubrepo
+
+import (
+	"context"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/giantswarm/microerror"
+	"github.com/google/go-github/v62/github"
+	"golang.org/x/oauth2"
+)
+
+type Config struct {
+	// Name of the GitHub organization owning our repository.
+	GithubOrganization string
+
+	// Github personal access token (PTA) to use for client authentication.
+	GithubAuthToken string
+}
+
+type Service struct {
+	config       Config
+	ctx          context.Context
+	githubClient *github.Client
+}
+
+// All the details of a GitHub repository that we care about.
+type RepoDetails struct {
+	Name          string
+	Description   string
+	IsPrivate     bool
+	DefaultBranch string
+	MainLanguage  string
+}
+
+// Instantiates a new service.
+func New(c Config) (*Service, error) {
+	if c.GithubOrganization == "" {
+		return nil, microerror.Maskf(invalidConfigError, "no Github organization configured")
+	}
+	if c.GithubAuthToken == "" {
+		log.Println("WARNING: No Github token given (env variable GITHUB_TOKEN not set)")
+	}
+
+	ts := oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: c.GithubAuthToken},
+	)
+
+	ctx := context.Background()
+	tc := oauth2.NewClient(ctx, ts)
+	client := github.NewClient(tc)
+
+	s := &Service{
+		config:       c,
+		ctx:          ctx,
+		githubClient: client,
+	}
+
+	return s, nil
+}
+
+// Load details for a specific repository.
+func (s *Service) GetDetails(name string) (*RepoDetails, error) {
+	repo, resp, err := s.githubClient.Repositories.Get(s.ctx, s.config.GithubOrganization, name)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, microerror.Maskf(repositoryNotFoundError, "repository %s not found", name)
+	}
+
+	details := &RepoDetails{
+		Name:          repo.GetName(),
+		Description:   repo.GetDescription(),
+		IsPrivate:     repo.GetPrivate(),
+		DefaultBranch: repo.GetDefaultBranch(),
+		MainLanguage:  strings.ToLower(repo.GetLanguage()),
+	}
+
+	return details, nil
+}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/29552

This should enable the Techdocs link in our repositories.