### PR TITLE
`installations` command also exports the base domain and account engineer name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- The `installations` command also exports the base domain and account engineer name.
+
 ## [0.15.0] - 2024-08-03
 
 ### Added

--- a/cmd/installations/installations.go
+++ b/cmd/installations/installations.go
@@ -127,6 +127,16 @@ func toResourceEntity(ins *installations.Installation) *bscatalog.Entity {
 		Spec: bscatalog.ComponentSpec{},
 	}
 
+	// Base domain
+	if ins.Base != "" {
+		r.Annotations["giantswarm.io/base"] = ins.Base
+	}
+
+	// Account engineer
+	if ins.AccountEngineer != "" {
+		r.Annotations["giantswarm.io/account-engineer"] = ins.AccountEngineer
+	}
+
 	// Escalation matrix
 	if ins.EscalationMatrix != "" {
 		r.Annotations["giantswarm.io/escalation-matrix"] = ins.EscalationMatrix


### PR DESCRIPTION
### What does this PR do?

This adds two more annotations to entities created by the `installations` command.

### Any background context you can provide?

https://github.com/giantswarm/giantswarm/issues/31294

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
