### PR TITLE
Add opsgenie.com/component-selector annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `installations` export now exports OpsGenie annotation to find alerts per installation.
+
 ## [0.15.2] - 2024-08-09
 
 ### Changed

--- a/cmd/installations/installations.go
+++ b/cmd/installations/installations.go
@@ -100,7 +100,8 @@ func toResourceEntity(ins *installations.Installation) *bscatalog.Entity {
 			"giantswarm.io/pipeline": ins.Pipeline,
 		},
 		Annotations: map[string]string{
-			"backstage.io/source-location": fmt.Sprintf("url:https://github.com/giantswarm/installations/blob/master/%s/cluster.yaml", ins.Codename),
+			"backstage.io/source-location":    fmt.Sprintf("url:https://github.com/giantswarm/installations/blob/master/%s/cluster.yaml", ins.Codename),
+			"opsgenie.com/component-selector": fmt.Sprintf("detailsPair(installation:%s)", ins.Codename),
 		},
 		Links: []bscatalog.EntityLink{
 			{


### PR DESCRIPTION
### What does this PR do?

Adds the `opsgenie.com/component-selector` annotation to each exported installation entity, to enable showing OpsGenie alerts for the installation.

### Any background context you can provide?

https://github.com/giantswarm/giantswarm/issues/31294

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
