### PR TITLE
Read top-level region key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- For installation resources, also read the region jey from the top level of the source file.
+
 ## [0.15.3] - 2024-08-12
 
 ### Added

--- a/cmd/installations/installations.go
+++ b/cmd/installations/installations.go
@@ -125,6 +125,11 @@ func toResourceEntity(ins *installations.Installation) *bscatalog.Entity {
 		r.Annotations["giantswarm.io/base"] = ins.Base
 	}
 
+	// Region
+	if ins.Region != "" {
+		r.Labels["giantswarm.io/region"] = ins.Region
+	}
+
 	// Account engineer
 	if ins.AccountEngineer != "" {
 		r.Annotations["giantswarm.io/account-engineer"] = ins.AccountEngineer
@@ -178,11 +183,6 @@ func toResourceEntity(ins *installations.Installation) *bscatalog.Entity {
 				Title: "AWS Console (workload clusters)",
 				Icon:  "aws",
 			})
-		}
-
-		// Region
-		if ins.Aws.Region != "" {
-			r.Labels["giantswarm.io/region"] = ins.Aws.Region
 		}
 	}
 

--- a/pkg/input/installations/installations.go
+++ b/pkg/input/installations/installations.go
@@ -134,5 +134,10 @@ func parseInstallationInfo(content []byte) (*Installation, error) {
 		return nil, err
 	}
 
+	// Copy region key to top position
+	if inst.Region == "" && inst.Aws.Region != "" {
+		inst.Region = inst.Aws.Region
+	}
+
 	return inst, nil
 }

--- a/pkg/input/installations/installations_test.go
+++ b/pkg/input/installations/installations_test.go
@@ -39,6 +39,7 @@ func Test_parseInstallationInfo(t *testing.T) {
 				EscalationMatrix: "Here is some information regarding how to escalate incidents\n",
 				Pipeline:         "stable",
 				Provider:         "aws",
+				Region:           "cn-northwest-1",
 				Slack:            &SlackDetails{Support: []string{"support-acme-admin"}},
 			},
 			wantErr: false,
@@ -58,6 +59,7 @@ func Test_parseInstallationInfo(t *testing.T) {
 				Slack:                  &SlackDetails{Support: []string{"support-acme-admin"}},
 				Pipeline:               "stable",
 				Provider:               "capa",
+				Region:                 "eu-west-1",
 				Aws: &AwsDetails{
 					Region: "eu-west-1",
 					HostCluster: AwsIdentity{
@@ -84,6 +86,7 @@ func Test_parseInstallationInfo(t *testing.T) {
 				Customer:               "giantswarm",
 				Pipeline:               "ephemeral",
 				Provider:               "capz",
+				Region:                 "fantasy-region",
 			},
 			wantErr: false,
 		},

--- a/pkg/input/installations/testdata/goose.yaml
+++ b/pkg/input/installations/testdata/goose.yaml
@@ -7,3 +7,4 @@ accountEngineer: Team Phoenix
 accountEngineersHandle: 'support-phoenix'
 pipeline: ephemeral
 provider: capz
+region: fantasy-region

--- a/pkg/input/installations/types.go
+++ b/pkg/input/installations/types.go
@@ -12,6 +12,7 @@ type Installation struct {
 	Slack                  *SlackDetails `yaml:"slack,omitempty"`
 	Pipeline               string        `yaml:"pipeline"`
 	Provider               string        `yaml:"provider"`
+	Region                 string        `yaml:"region"`
 	Aws                    *AwsDetails   `yaml:"aws,omitempty"`
 }
 


### PR DESCRIPTION
To account for our Azure installations, which have the region key in the top level of cluster.yaml, we add reading of that key and harmonize Aws with the rest.

This is needed to add the region information for our Azure installations.