### PR TITLE
Fix Go dependency detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed detection of Go dependencies via the Github API
+
 ## [0.16.0] - 2024-09-25
 
 ### Removed

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -161,6 +161,7 @@ func runRoot(cmd *cobra.Command, args []string) {
 				if err != nil {
 					log.Printf("WARN - %s: error fetching dependencies: %v", repo.Name, err)
 				}
+				log.Printf("DEBUG - found %d dependencies for repo %q", len(deps), repo.Name)
 
 				for _, d := range deps {
 					dependencies[d] = append(dependencies[d], fmt.Sprintf("used in [%s](https://github.com/%s/%s) owned by @%s/%s", repo.Name, githubOrganization, repo.Name, githubOrganization, list.OwnerTeamName))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -161,7 +161,6 @@ func runRoot(cmd *cobra.Command, args []string) {
 				if err != nil {
 					log.Printf("WARN - %s: error fetching dependencies: %v", repo.Name, err)
 				}
-				log.Printf("DEBUG - found %d dependencies for repo %q", len(deps), repo.Name)
 
 				for _, d := range deps {
 					dependencies[d] = append(dependencies[d], fmt.Sprintf("used in [%s](https://github.com/%s/%s) owned by @%s/%s", repo.Name, githubOrganization, repo.Name, githubOrganization, list.OwnerTeamName))

--- a/pkg/input/repositories/dependencies.go
+++ b/pkg/input/repositories/dependencies.go
@@ -22,6 +22,8 @@ type SbomPackage struct {
 }
 
 // Returns list of dependencies.
+//
+// Repository name is given by the `name` parameter.
 func (s *Service) GetDependencies(name string) ([]string, error) {
 	sbom, resp, err := s.githubClient.DependencyGraph.GetSBOM(s.ctx, s.config.GithubOrganization, name)
 	if err != nil {
@@ -36,11 +38,12 @@ func (s *Service) GetDependencies(name string) ([]string, error) {
 	}
 
 	names := []string{}
-	godepRegex := regexp.MustCompile("go:github.com/giantswarm/([^/]+).*")
+	godepRegex := regexp.MustCompile("github.com/giantswarm/([^/]+).*")
 
 	for _, item := range sbom.SBOM.Packages {
+		//log.Printf("DEBUG - SBOM name %q", *item.Name)
 		// We only want these:
-		// 'go:github.com/giantswarm/NAME'
+		// 'github.com/giantswarm/NAME'
 		matches := godepRegex.FindStringSubmatch(*item.Name)
 		if len(matches) > 0 {
 			names = append(names, matches[1])

--- a/pkg/input/repositories/repositories.go
+++ b/pkg/input/repositories/repositories.go
@@ -38,6 +38,9 @@ type ListResult struct {
 	Repositories  []Repo
 }
 
+// A service to access information Giant Swarm stores about
+// GitHub repositories, as well as some additional details
+// fetched from the GitHub API.
 type Service struct {
 	config       Config
 	ctx          context.Context


### PR DESCRIPTION
### What does this PR do?

This PR fixes the problem that we no longer showed any dependencies between Go components in our catalogs.

Github has decided to remove the `go:` package name prefix from their API results, so our name matching needed an update.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
