### PR TITLE
Create Giant Swarm user entities based on Personio information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- User export takes employee data from Personio into account
+
 ## [0.16.1] - 2024-11-22
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - User export takes employee data from Personio into account
 
+### Removed
+
+- Removed `--org` flag from command `users`.
+
 ## [0.16.1] - 2024-11-22
 
 ### Fixed

--- a/cmd/users/users.go
+++ b/cmd/users/users.go
@@ -36,11 +36,11 @@ func run(cmd *cobra.Command, args []string) error {
 	// Personio credentials
 	personioClientID := os.Getenv("PERSONIO_CLIENT_ID")
 	if personioClientID == "" {
-		log.Fatal("Please set environment variable PERSONIO_CLIENT_ID to a the Personio client ID.")
+		log.Fatal("Please set environment variable PERSONIO_CLIENT_ID to the Personio client ID.")
 	}
 	personioClientSecret := os.Getenv("PERSONIO_CLIENT_SECRET")
 	if personioClientSecret == "" {
-		log.Fatal("Please set environment variable PERSONIO_CLIENT_SECRET to a the Personio client secret.")
+		log.Fatal("Please set environment variable PERSONIO_CLIENT_SECRET to the Personio client secret.")
 	}
 
 	// GitHub credentials

--- a/cmd/users/users.go
+++ b/cmd/users/users.go
@@ -5,12 +5,12 @@ import (
 	"context"
 	"log"
 	"os"
-	"sort"
 
 	"github.com/google/go-github/v67/github"
 	"github.com/spf13/cobra"
 	"golang.org/x/oauth2"
 
+	"github.com/giantswarm/backstage-catalog-importer/pkg/input/personio"
 	"github.com/giantswarm/backstage-catalog-importer/pkg/output/catalog/user"
 	"github.com/giantswarm/backstage-catalog-importer/pkg/output/export"
 )
@@ -24,18 +24,26 @@ var Command = &cobra.Command{
 
 const (
 	internalFlag = "internal"
-	orgFlag      = "org"
 	outputFlag   = "output"
 )
 
 func init() {
 	Command.Flags().BoolP(internalFlag, "i", false, "Create a Giant Swarm internal catalog, which includes email adresses.")
-	Command.Flags().String(orgFlag, "giantswarm", "GitHub organization to export users from")
-
 	Command.PersistentFlags().StringP(outputFlag, "o", ".", "Output directory path")
 }
 
 func run(cmd *cobra.Command, args []string) error {
+	// Personio credentials
+	personioClientID := os.Getenv("PERSONIO_CLIENT_ID")
+	if personioClientID == "" {
+		log.Fatal("Please set environment variable PERSONIO_CLIENT_ID to a the Personio client ID.")
+	}
+	personioClientSecret := os.Getenv("PERSONIO_CLIENT_SECRET")
+	if personioClientSecret == "" {
+		log.Fatal("Please set environment variable PERSONIO_CLIENT_SECRET to a the Personio client secret.")
+	}
+
+	// GitHub credentials
 	token := os.Getenv("GITHUB_TOKEN")
 	if token == "" {
 		log.Fatal("Please set environment variable GITHUB_TOKEN to a personal GitHub access token (PAT).")
@@ -51,72 +59,57 @@ func run(cmd *cobra.Command, args []string) error {
 		log.Fatalf("Error: could not access 'output' flag - %s", err)
 	}
 
-	org, err := cmd.Flags().GetString(orgFlag)
-	if err != nil {
-		log.Fatalf("Error: could not access 'org' flag - %s", err)
-	}
+	ctx := context.Background()
 
 	// Github client
-	ctx := context.Background()
 	ts := oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: token},
 	)
 	tc := oauth2.NewClient(ctx, ts)
-	client := github.NewClient(tc)
+	githubClient := github.NewClient(tc)
 
 	userExporter := export.New(export.Config{TargetPath: path + "/users.yaml"})
-	numUsers := 0
 
-	opt := &github.ListMembersOptions{
-		PublicOnly:  false,
-		ListOptions: github.ListOptions{PerPage: 100},
-	}
-	var allMembers []*github.User
-	for {
-		members, resp, err := client.Organizations.ListMembers(ctx, org, opt)
-		if err != nil {
-			log.Fatalf("Error: could not list organization members -- %v", err)
-		}
-		allMembers = append(allMembers, members...)
-		if resp.NextPage == 0 {
-			break
-		}
-		opt.Page = resp.NextPage
+	employees, err := personio.GetActiveEmployees(ctx, personioClientID, personioClientSecret)
+	if err != nil {
+		log.Fatalf("Error: could not get employees from Personio -- %v", err)
 	}
 
-	// Sort by user name
-	sort.Slice(allMembers, func(i, j int) bool {
-		return allMembers[i].GetLogin() < allMembers[j].GetLogin()
-	})
-
-	for _, githubUser := range allMembers {
-		detailedUser, _, err := client.Users.Get(ctx, githubUser.GetLogin())
+	for _, employee := range employees {
+		// Get Github details for each employee
+		if employee.GithubHandle == "" {
+			// If the user has no GitHub handle, we skip them
+			log.Printf("Warning: no GitHub handle found for %s %s (%s) -- skipping", employee.FirstName, employee.LastName, employee.Email)
+			continue
+		}
+		githubDetails, _, err := githubClient.Users.Get(ctx, employee.GithubHandle)
 		if err != nil {
 			log.Fatalf("Error: could not read detailed user entry -- %v", err)
 		}
 
-		user, err := user.New(githubUser.GetLogin(),
-			user.WithDisplayName(detailedUser.GetName()),
-			user.WithPictureURL(detailedUser.GetAvatarURL()),
-			user.WithDescription(detailedUser.GetBio()),
+		user, err := user.New(employee.GithubHandle,
+			user.WithPictureURL(githubDetails.GetAvatarURL()),
+			user.WithDescription(githubDetails.GetBio()),
+			user.WithEmail(employee.Email),
+			user.WithGitHubHandle(employee.GithubHandle),
+			user.WithGitHubID(githubDetails.GetID()),
 		)
 		if err != nil {
 			log.Fatalf("Error: could not create user - %v", err)
 		}
 
 		if internal {
-			// Email will only be published internally at Giant Swarm
-			user.Email = detailedUser.GetEmail()
+			user.DisplayName = employee.FirstName + " " + employee.LastName
 		} else {
 			// In customer catalogs, Giant Swarm entities use the "giantswarm" namespace
 			user.Namespace = "giantswarm"
+			user.DisplayName = githubDetails.GetName()
 		}
 
 		err = userExporter.AddEntity(user.ToEntity())
 		if err != nil {
 			log.Fatalf("Error: could not add user entity - %v", err)
 		}
-		numUsers++
 	}
 
 	err = userExporter.WriteFile()

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,9 +31,9 @@ To discover teams, we read all teams of the `giantswarm` organization from the G
 
 TODO: This method is suited for Giant Swarm only. For customer catalogs, we need a different solution. First, we don't want to export information on teams that are not relevant to the customer. Second, we may want to publish customer's teams.
 
-## GitHub user discovery
+## User discovery
 
-We read all users that are member of the "giantswarm" GitHub org by default.
+We export all Personio employee entries that have the `status` field set to `active`.
 
 ## Giant Swarm app catalog discovery
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ toolchain go1.23.4
 
 require (
 	github.com/giantswarm/microerror v0.4.1
+	github.com/giantswarm/personio-go v0.6.0
 	github.com/google/go-cmp v0.6.0
 	github.com/google/go-github/v67 v67.0.0
 	github.com/spf13/cobra v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/giantswarm/microerror v0.4.1 h1:WMiD7HQASoUA9lZzPlPK+erCEOJ0uT4cyo18VfCXHD0=
 github.com/giantswarm/microerror v0.4.1/go.mod h1:URFj0gFCmZihjya6saQCXxslBrgctXb4NsXYHB5JdrI=
+github.com/giantswarm/personio-go v0.6.0 h1:PQZKSG33ppghrVLyvvhl7eJvOaRh5Ui1KnPDngWngDI=
+github.com/giantswarm/personio-go v0.6.0/go.mod h1:4R6PohJg6uCIm0nErfI4OzdyXt+iJc0Q1iGB6/jFOUw=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=

--- a/pkg/input/personio/personio.go
+++ b/pkg/input/personio/personio.go
@@ -32,6 +32,11 @@ func GetEmployees(ctx context.Context, clientID, clientSecret string) ([]Employe
 
 	var result []Employee
 	for _, employee := range employees {
+		// only return active employees
+		if *employee.GetStringAttribute("status") != "active" {
+			continue
+		}
+
 		log.Printf("Employee: %s %s email=%s github=%s",
 			*employee.GetStringAttribute("first_name"),
 			*employee.GetStringAttribute("last_name"),

--- a/pkg/input/personio/personio.go
+++ b/pkg/input/personio/personio.go
@@ -2,7 +2,6 @@ package personio
 
 import (
 	"context"
-	"log"
 	"sort"
 
 	personiov1 "github.com/giantswarm/personio-go/v1"
@@ -37,12 +36,6 @@ func GetEmployees(ctx context.Context, clientID, clientSecret string) ([]Employe
 			continue
 		}
 
-		log.Printf("Employee: %s %s email=%s github=%s",
-			*employee.GetStringAttribute("first_name"),
-			*employee.GetStringAttribute("last_name"),
-			*employee.GetStringAttribute("email"),
-			*employee.GetStringAttribute("dynamic_3196204"), // GitHub username
-		)
 		result = append(result, Employee{
 			FirstName:    *employee.GetStringAttribute("first_name"),
 			LastName:     *employee.GetStringAttribute("last_name"),

--- a/pkg/input/personio/personio.go
+++ b/pkg/input/personio/personio.go
@@ -14,8 +14,8 @@ type Employee struct {
 	GithubHandle string
 }
 
-// Returns employee information from personio.
-func GetEmployees(ctx context.Context, clientID, clientSecret string) ([]Employee, error) {
+// Returns information on active employees from personio.
+func GetActiveEmployees(ctx context.Context, clientID, clientSecret string) ([]Employee, error) {
 	client, err := personiov1.NewClient(ctx, personiov1.DefaultBaseUrl, personiov1.Credentials{
 		ClientId:     clientID,
 		ClientSecret: clientSecret,

--- a/pkg/input/personio/personio.go
+++ b/pkg/input/personio/personio.go
@@ -7,6 +7,13 @@ import (
 	personiov1 "github.com/giantswarm/personio-go/v1"
 )
 
+const (
+	githubHandleFieldName = "dynamic_3196204"
+	firstNameFieldName    = "first_name"
+	lastNameFieldName     = "last_name"
+	emailFieldName        = "email"
+)
+
 type Employee struct {
 	FirstName    string
 	LastName     string
@@ -37,10 +44,10 @@ func GetActiveEmployees(ctx context.Context, clientID, clientSecret string) ([]E
 		}
 
 		result = append(result, Employee{
-			FirstName:    *employee.GetStringAttribute("first_name"),
-			LastName:     *employee.GetStringAttribute("last_name"),
-			Email:        *employee.GetStringAttribute("email"),
-			GithubHandle: *employee.GetStringAttribute("dynamic_3196204"),
+			FirstName:    *employee.GetStringAttribute(firstNameFieldName),
+			LastName:     *employee.GetStringAttribute(lastNameFieldName),
+			Email:        *employee.GetStringAttribute(emailFieldName),
+			GithubHandle: *employee.GetStringAttribute(githubHandleFieldName),
 		})
 	}
 

--- a/pkg/input/personio/personio.go
+++ b/pkg/input/personio/personio.go
@@ -3,31 +3,53 @@ package personio
 import (
 	"context"
 	"log"
+	"sort"
 
 	personiov1 "github.com/giantswarm/personio-go/v1"
 )
 
-func Lookup() error {
-	var personioCredentials personiov1.Credentials
+type Employee struct {
+	FirstName    string
+	LastName     string
+	Email        string
+	GithubHandle string
+}
 
-	client, err := personiov1.NewClient(context.TODO(), personiov1.DefaultBaseUrl, personioCredentials)
+// Returns employee information from personio.
+func GetEmployees(ctx context.Context, clientID, clientSecret string) ([]Employee, error) {
+	client, err := personiov1.NewClient(ctx, personiov1.DefaultBaseUrl, personiov1.Credentials{
+		ClientId:     clientID,
+		ClientSecret: clientSecret,
+	})
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	employees, err := client.GetEmployees()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
+	var result []Employee
 	for _, employee := range employees {
 		log.Printf("Employee: %s %s email=%s github=%s",
 			*employee.GetStringAttribute("first_name"),
 			*employee.GetStringAttribute("last_name"),
 			*employee.GetStringAttribute("email"),
-			*employee.GetStringAttribute("github_username"),
+			*employee.GetStringAttribute("dynamic_3196204"), // GitHub username
 		)
+		result = append(result, Employee{
+			FirstName:    *employee.GetStringAttribute("first_name"),
+			LastName:     *employee.GetStringAttribute("last_name"),
+			Email:        *employee.GetStringAttribute("email"),
+			GithubHandle: *employee.GetStringAttribute("dynamic_3196204"),
+		})
 	}
 
-	return nil
+	// Sort the slice by email in ascending order
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Email < result[j].Email
+	})
+
+	return result, nil
 }

--- a/pkg/input/personio/personio.go
+++ b/pkg/input/personio/personio.go
@@ -1,0 +1,33 @@
+package personio
+
+import (
+	"context"
+	"log"
+
+	personiov1 "github.com/giantswarm/personio-go/v1"
+)
+
+func Lookup() error {
+	var personioCredentials personiov1.Credentials
+
+	client, err := personiov1.NewClient(context.TODO(), personiov1.DefaultBaseUrl, personioCredentials)
+	if err != nil {
+		return err
+	}
+
+	employees, err := client.GetEmployees()
+	if err != nil {
+		return err
+	}
+
+	for _, employee := range employees {
+		log.Printf("Employee: %s %s email=%s github=%s",
+			*employee.GetStringAttribute("first_name"),
+			*employee.GetStringAttribute("last_name"),
+			*employee.GetStringAttribute("email"),
+			*employee.GetStringAttribute("github_username"),
+		)
+	}
+
+	return nil
+}

--- a/pkg/output/catalog/user/options.go
+++ b/pkg/output/catalog/user/options.go
@@ -41,3 +41,15 @@ func WithGroups(names ...string) Option {
 		c.Groups = names
 	}
 }
+
+func WithGitHubHandle(handle string) Option {
+	return func(c *User) {
+		c.GitHubHandle = handle
+	}
+}
+
+func WithGitHubID(id int64) Option {
+	return func(c *User) {
+		c.GitHubID = id
+	}
+}

--- a/pkg/output/catalog/user/user.go
+++ b/pkg/output/catalog/user/user.go
@@ -18,7 +18,7 @@ type Option func(*User)
 // User holds our internal representation of something that we want
 // to export as a User entity.
 type User struct {
-	// User name (required)
+	// User identifier (required)
 	Name string
 
 	// Namespace, defaults to "default"
@@ -34,6 +34,9 @@ type User struct {
 	Description string
 	Email       string
 	PictureURL  string
+
+	GitHubHandle string
+	GitHubID     int64
 
 	// Names of groups the user is a member of
 	Groups []string
@@ -76,12 +79,20 @@ func (c *User) ToEntity() *bscatalog.Entity {
 			Name:        c.Name,
 			Description: c.Description,
 			Title:       c.Title,
+			Annotations: map[string]string{},
 		},
 		Spec: spec,
 	}
 
 	if c.Namespace != "" && c.Namespace != defaultNamespace {
 		e.Metadata.Namespace = c.Namespace
+	}
+
+	if c.GitHubID != 0 {
+		e.Metadata.Annotations["github.com/user-id"] = fmt.Sprintf("%d", c.GitHubID)
+	}
+	if c.GitHubHandle != "" {
+		e.Metadata.Annotations["github.com/user-login"] = c.GitHubHandle
 	}
 
 	return e

--- a/pkg/output/catalog/user/user.go
+++ b/pkg/output/catalog/user/user.go
@@ -87,17 +87,17 @@ func (c *User) ToEntity() *bscatalog.Entity {
 		e.Metadata.Namespace = c.Namespace
 	}
 
-	if c.GitHubID != 0 {
+	if c.GitHubHandle != "" || c.GitHubID != 0 {
 		if e.Metadata.Annotations == nil {
 			e.Metadata.Annotations = make(map[string]string)
 		}
-		e.Metadata.Annotations["github.com/user-id"] = fmt.Sprintf("%d", c.GitHubID)
-	}
-	if c.GitHubHandle != "" {
-		if e.Metadata.Annotations == nil {
-			e.Metadata.Annotations = make(map[string]string)
+
+		if c.GitHubID != 0 {
+			e.Metadata.Annotations["github.com/user-id"] = fmt.Sprintf("%d", c.GitHubID)
 		}
-		e.Metadata.Annotations["github.com/user-login"] = c.GitHubHandle
+		if c.GitHubHandle != "" {
+			e.Metadata.Annotations["github.com/user-login"] = c.GitHubHandle
+		}
 	}
 
 	return e

--- a/pkg/output/catalog/user/user.go
+++ b/pkg/output/catalog/user/user.go
@@ -79,7 +79,6 @@ func (c *User) ToEntity() *bscatalog.Entity {
 			Name:        c.Name,
 			Description: c.Description,
 			Title:       c.Title,
-			Annotations: map[string]string{},
 		},
 		Spec: spec,
 	}
@@ -89,9 +88,15 @@ func (c *User) ToEntity() *bscatalog.Entity {
 	}
 
 	if c.GitHubID != 0 {
+		if e.Metadata.Annotations == nil {
+			e.Metadata.Annotations = make(map[string]string)
+		}
 		e.Metadata.Annotations["github.com/user-id"] = fmt.Sprintf("%d", c.GitHubID)
 	}
 	if c.GitHubHandle != "" {
+		if e.Metadata.Annotations == nil {
+			e.Metadata.Annotations = make(map[string]string)
+		}
 		e.Metadata.Annotations["github.com/user-login"] = c.GitHubHandle
 	}
 

--- a/pkg/output/catalog/user/user_test.go
+++ b/pkg/output/catalog/user/user_test.go
@@ -41,11 +41,17 @@ func TestUser_ToEntity(t *testing.T) {
 				WithDescription("A full-fledged user"),
 				WithPictureURL("https://example.com/picture.jpg"),
 				WithGroups("group2", "group1"),
+				WithGitHubHandle("github-handle"),
+				WithGitHubID(123),
 			},
 			want: &bscatalog.Entity{
 				APIVersion: "backstage.io/v1alpha1",
 				Kind:       bscatalog.EntityKindUser,
 				Metadata: bscatalog.EntityMetadata{
+					Annotations: map[string]string{
+						"github.com/user-id":    "123",
+						"github.com/user-login": "github-handle",
+					},
 					Name:        "full-fledged-user",
 					Description: "A full-fledged user",
 					Title:       "Full Fledged",


### PR DESCRIPTION
### What does this PR do?

Changes user catalog creation so that

- employee information is read from Personio
- if employee has GitHub user name in Personio, additional info is fetched from GitHub
- email address from personio and GitHub numeric user ID are added to the exported entities
- the email address will also be exported if the export command is invoked without the `--internal` flag, to facilitate authentication

Preview:

```diff
apiVersion: backstage.io/v1alpha1
kind: User
metadata:
    name: marians
    namespace: giantswarm
    description: Designing your experience with @giantswarm
+   annotations:
+       github.com/user-id: "273727"
+       github.com/user-login: marians
spec:
    profile:
        displayName: Marian Steinbach
+       email: marian@giantswarm.io
        picture: https://avatars.githubusercontent.com/u/273727?v=4
    memberOf: []
```

### Any background context you can provide?

https://github.com/giantswarm/giantswarm/issues/32234

### Do the docs need to be updated?

Yes

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
