### PR TITLE
installations: detect custom CA and export as annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `installations` command sets the `giantswarm.io/custom-ca` annotation if the installation data provides a custom CA certificate.
+
 ## [0.18.1] - 2025-01-22
 
 - Dependency update

--- a/cmd/installations/installations.go
+++ b/cmd/installations/installations.go
@@ -124,6 +124,11 @@ func toResourceEntity(ins *installations.Installation) *bscatalog.Entity {
 		r.Annotations["giantswarm.io/base"] = ins.Base
 	}
 
+	// Custom CA
+	if ins.CustomCA != "" {
+		r.Annotations["giantswarm.io/custom-ca"] = ins.CustomCA
+	}
+
 	// Region
 	if ins.Region != "" {
 		r.Labels["giantswarm.io/region"] = ins.Region

--- a/pkg/input/installations/types.go
+++ b/pkg/input/installations/types.go
@@ -14,6 +14,7 @@ type Installation struct {
 	Provider               string        `yaml:"provider"`
 	Region                 string        `yaml:"region"`
 	Aws                    *AwsDetails   `yaml:"aws,omitempty"`
+	CustomCA               string
 }
 
 type SlackDetails struct {


### PR DESCRIPTION
### What does this PR do?

In order to access some installations, Giant Swarm staff needs custom CA certificates installed and trusted. To learn about this fact, we want to display that information in the Backstage portal.

If the repo data for an installations provides a custom CA cert (`ca.pem`), the URL of that file is exported in the `giantswarm.io/custom-ca` annotation.

Also removes the unused but exported `GetInstallationFile` function.

### Do the docs need to be updated?

No

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
