### PR TITLE
Add links for Grafana and Policy Reporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- In installation resource entities, more links are added. One additional Grafana link and one to Policy Reporter, both via Teleport.
+
 ## [0.20.0] - 2025-02-25
 
 ### Added

--- a/cmd/installations/installations.go
+++ b/cmd/installations/installations.go
@@ -165,13 +165,21 @@ func toResourceEntity(ins *installations.Installation) *bscatalog.Entity {
 	} else {
 		r.Links = append(r.Links, []bscatalog.EntityLink{
 			{
+				URL:   fmt.Sprintf("https://grafana-%s.teleport.giantswarm.io", ins.Codename),
+				Title: "Grafana (via Teleport)",
+				Icon:  "grafana",
+			}, {
+				URL:   fmt.Sprintf("https://grafana.%s.%s/", ins.Codename, ins.Base),
+				Title: "Grafana (customer URL)",
+				Icon:  "grafana",
+			}, {
 				URL:   fmt.Sprintf("https://happa.%s.%s/admin-login", ins.Codename, ins.Base),
 				Title: "Happa",
 				Icon:  "giantswarm",
 			}, {
-				URL:   fmt.Sprintf("https://grafana.%s.%s/", ins.Codename, ins.Base),
-				Title: "Grafana",
-				Icon:  "grafana",
+				URL:   fmt.Sprintf("https://grafana-%s.teleport.giantswarm.io", ins.Codename),
+				Title: "Policy Reporter (via Teleport)",
+				Icon:  "dashboard",
 			},
 		}...)
 	}


### PR DESCRIPTION
Two more links for Giant Swarm staff, per installation.

- Grafana via Teleport
- Policy Reporter via Teleport

### Do the docs need to be updated?

No

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
