### PR TITLE
Fix repository lookup in appcatalogs command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The `appcatalogs` command now uses the repository slug found in chart URLs to find the repository for a chart.
+
 ## [0.21.1] - 2025-04-09
 
 ### Fixed

--- a/cmd/appcatalogs/appcatalogs.go
+++ b/cmd/appcatalogs/appcatalogs.go
@@ -125,6 +125,7 @@ func runAppCatalogs(cmd *cobra.Command, args []string) {
 
 			apps[appName]++
 
+			// Get details from the first release entry (expected to be the latest)
 			component, err := componentFromCatalogEntry(index.Entries[appName][0], repoService)
 			if err != nil {
 				log.Printf("ERROR: Could not create component entity. %v", err)
@@ -243,7 +244,12 @@ func componentFromCatalogEntry(entry helmrepoindex.Entry, service *githubrepo.Se
 		return nil, fmt.Errorf("could not detect GitHub slug for app %s in app metadata", entry.Name)
 	}
 
-	repoDetails, err := service.GetDetails(entry.Name)
+	repoParts := strings.Split(githubSlug, "/")
+	if len(repoParts) < 2 {
+		return nil, fmt.Errorf("invalid GitHub slug %q for app %s in app metadata", githubSlug, entry.Name)
+	}
+
+	repoDetails, err := service.GetDetails(repoParts[1])
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/appcatalogs/appcatalogs_test.go
+++ b/cmd/appcatalogs/appcatalogs_test.go
@@ -64,6 +64,14 @@ func Test_detectGitHubSlug(t *testing.T) {
 			},
 			want: "giantswarm/project-slug",
 		},
+		{
+			name: "url-found-in-home-wins-over-sources",
+			entry: &helmrepoindex.Entry{
+				Home:    "https://github.com/giantswarm/alloy-gateway-app",
+				Sources: []string{"https://github.com/giantswarm/other-project"},
+			},
+			want: "giantswarm/alloy-gateway-app",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

This PR changes the way the `appcatalogs` command tries to find matching a GitHub repository for each chart. This is critical for the resulting export, as we only export entities that have a matching GitHub repo.

Previously we made an attempt to get the GitHub project slug from the URLs mentioned in the chart metadata, but then didn't use that slug. 🙄 We used the chart name instead, which cause many misses. Now we are using the slug.

The results are shown in https://github.com/giantswarm/backstage-catalogs/pull/217

These three components that were previously generated are no longe rcreated:

- azure-storageclasses: The home URL in the chart is wrong. Fix in progress.
- prometheus-remotewrite: The home URL in the chart is wrong. Fix in progress.
- promxy-app: The home URL in the chart is wrong and the repository is archived. won't fix.

### Any background context you can provide?

- https://github.com/giantswarm/giantswarm/issues/33259

### Should this change be mentioned in the release notes?

- [ ] CHANGELOG.md has been updated (if it exists)
