### PR TITLE
Use public OCI registry for private repos with force-public in CircleCI config

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -132,7 +132,13 @@ func runRoot(cmd *cobra.Command, args []string) {
 				log.Fatalf("Error: %v", err)
 			}
 			if isPrivate {
-				ociRegistry = privateOciRegistry
+				forcePublic, err := repoService.GetForcePublicRegistry(repo.Name)
+				if err != nil {
+					log.Fatalf("Error: %v", err)
+				}
+				if !forcePublic {
+					ociRegistry = privateOciRegistry
+				}
 			}
 
 			hasReadme, err := repoService.GetHasReadme(repo.Name)

--- a/pkg/input/repositories/repositories.go
+++ b/pkg/input/repositories/repositories.go
@@ -145,9 +145,20 @@ func (s *Service) loadGithubRepoContentDetails(name string) error {
 	details := GithubRepoContentDetails{}
 
 	// Detect CircleCI
-	_, _, resp, err := s.githubClient.Repositories.GetContents(s.ctx, s.config.GithubOrganization, name, ".circleci/config.yml", nil)
+	circleciFileContent, _, resp, err := s.githubClient.Repositories.GetContents(s.ctx, s.config.GithubOrganization, name, ".circleci/config.yml", nil)
 	if err == nil {
 		details.HasCircleCI = true
+
+		// Check if push-to-registries uses force-public: true
+		if circleciFileContent != nil {
+			content, contentErr := circleciFileContent.GetContent()
+			if contentErr == nil {
+				details.ForcePublicRegistry = circleciConfigHasForcePublic(content)
+				if details.ForcePublicRegistry {
+					log.Printf("DEBUG - %s - CircleCI config has force-public: true in push-to-registries\n", name)
+				}
+			}
+		}
 	} else if resp.StatusCode != http.StatusNotFound {
 		// 404 is a "not found" error, which is expected. Everything else is not expected.
 		return err
@@ -355,6 +366,19 @@ func (s *Service) GetHasCircleCI(name string) (bool, error) {
 	return s.githubRepoContentDetails[name].HasCircleCI, nil
 }
 
+// Returns whether the repo's CircleCI config uses force-public in push-to-registries,
+// meaning charts/images go to the public registry despite the repo being private.
+func (s *Service) GetForcePublicRegistry(name string) (bool, error) {
+	if _, ok := s.githubRepoContentDetails[name]; !ok {
+		err := s.loadGithubRepoContentDetails(name)
+		if err != nil {
+			return false, microerror.Mask(err)
+		}
+	}
+
+	return s.githubRepoContentDetails[name].ForcePublicRegistry, nil
+}
+
 // Returns whether the repo has a main README file.
 func (s *Service) GetHasReadme(name string) (bool, error) {
 	if _, ok := s.githubRepoContentDetails[name]; !ok {
@@ -389,4 +413,40 @@ func (s *Service) GetHelmChartNames(name string) ([]string, error) {
 	}
 
 	return s.githubRepoContentDetails[name].HelmChartNames, nil
+}
+
+// circleciConfigHasForcePublic parses a CircleCI config YAML and checks whether
+// any push-to-registries job in the workflows section has force-public: true.
+func circleciConfigHasForcePublic(configYAML string) bool {
+	var config struct {
+		Workflows map[string]struct {
+			Jobs []map[string]any `yaml:"jobs"`
+		} `yaml:"workflows"`
+	}
+
+	if err := yaml.Unmarshal([]byte(configYAML), &config); err != nil {
+		return false
+	}
+
+	for _, workflow := range config.Workflows {
+		for _, job := range workflow.Jobs {
+			for jobName, jobConfig := range job {
+				// Match job names like "architect/push-to-registries" or "push-to-registries"
+				if !strings.HasSuffix(jobName, "push-to-registries") {
+					continue
+				}
+				params, ok := jobConfig.(map[string]any)
+				if !ok {
+					continue
+				}
+				if forcePublic, exists := params["force-public"]; exists {
+					if val, ok := forcePublic.(bool); ok && val {
+						return true
+					}
+				}
+			}
+		}
+	}
+
+	return false
 }

--- a/pkg/input/repositories/repositories_test.go
+++ b/pkg/input/repositories/repositories_test.go
@@ -63,7 +63,7 @@ workflows:
 			want: false,
 		},
 		{
-			name: "empty config",
+			name:   "empty config",
 			config: ``,
 			want:   false,
 		},

--- a/pkg/input/repositories/repositories_test.go
+++ b/pkg/input/repositories/repositories_test.go
@@ -10,6 +10,90 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
+func TestCircleciConfigHasForcePublic(t *testing.T) {
+	tests := []struct {
+		name   string
+		config string
+		want   bool
+	}{
+		{
+			name: "force-public true on push-to-registries",
+			config: `version: 2.1
+workflows:
+  build:
+    jobs:
+      - architect/push-to-registries:
+          context: architect
+          force-public: true
+`,
+			want: true,
+		},
+		{
+			name: "force-public false on push-to-registries",
+			config: `version: 2.1
+workflows:
+  build:
+    jobs:
+      - architect/push-to-registries:
+          context: architect
+          force-public: false
+`,
+			want: false,
+		},
+		{
+			name: "no force-public on push-to-registries",
+			config: `version: 2.1
+workflows:
+  build:
+    jobs:
+      - architect/push-to-registries:
+          context: architect
+`,
+			want: false,
+		},
+		{
+			name: "no push-to-registries job",
+			config: `version: 2.1
+workflows:
+  build:
+    jobs:
+      - architect/go-build:
+          context: architect
+`,
+			want: false,
+		},
+		{
+			name: "empty config",
+			config: ``,
+			want:   false,
+		},
+		{
+			name:   "invalid YAML",
+			config: `{{{invalid`,
+			want:   false,
+		},
+		{
+			name: "push-to-registries as simple string entry",
+			config: `version: 2.1
+workflows:
+  build:
+    jobs:
+      - architect/push-to-registries
+`,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := circleciConfigHasForcePublic(tt.config)
+			if got != tt.want {
+				t.Errorf("circleciConfigHasForcePublic() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestLoadListShallow(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/pkg/input/repositories/types.go
+++ b/pkg/input/repositories/types.go
@@ -65,6 +65,11 @@ type GithubRepoContentDetails struct {
 	// Whether the repository has a CircleCI configuration file.
 	HasCircleCI bool
 
+	// Whether the CircleCI config uses force-public in push-to-registries,
+	// meaning charts/images are published to the public registry even though
+	// the repository is private.
+	ForcePublicRegistry bool
+
 	// Whether the repository has a README.md in the root directory.
 	HasReadme bool
 


### PR DESCRIPTION
## Summary
- Private repos that set `force-public: true` on the `push-to-registries` CircleCI job publish charts/images to the public registry (`gsoci.azurecr.io`), but the importer was unconditionally using the private registry (`gsociprivate.azurecr.io`) for all private repos
- Parse the `.circleci/config.yml` to detect `force-public: true` on `push-to-registries` jobs and use the public registry in that case
- Added unit tests for the CircleCI config YAML parsing

Closes https://github.com/giantswarm/giantswarm/issues/36250

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (including 7 new unit tests for `circleciConfigHasForcePublic`)
- [ ] Verify that `web-assets` (private repo with `force-public: true`) gets `gsoci.azurecr.io` instead of `gsociprivate.azurecr.io` in the generated catalog

🤖 Generated with [Claude Code](https://claude.com/claude-code)