### PR TITLE
Drop latest-release-tag and latest-release-date annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Remove `giantswarm.io/latest-release-tag` and `giantswarm.io/latest-release-date` annotations from exported components (root and charts commands). The `no-releases` tag is no longer emitted either.
+
 ## [0.28.1] - 2026-03-31
 
 ### Fixed

--- a/cmd/charts/charts.go
+++ b/cmd/charts/charts.go
@@ -8,7 +8,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/spf13/cobra"
 
@@ -231,28 +230,16 @@ func createComponentFromOCIChart(repo string, tag string, manifestInfo *ociregis
 		}
 	}
 
-	// Extract version, appVersion, creation time, icon, team owner, and chart type
+	// Extract version, appVersion, icon, team owner, and chart type
 	chartVersion := tag
 	var appVersion string
 	var chartType string
-	createdTime := time.Time{} // Zero value, will be set from manifest annotations
 	var iconURL string
 	componentOwner := "group:unspecified" // Default owner
 
 	// See https://github.com/giantswarm/roadmap/issues/4156#issuecomment-3589340419
 	managed := false
 	audience := audienceAll
-
-	// Extract creation time from OCI manifest annotations
-	if manifestInfo.Annotations != nil {
-		if created, ok := manifestInfo.Annotations["org.opencontainers.image.created"]; ok && created != "" {
-			if t, err := time.Parse(time.RFC3339, created); err == nil {
-				createdTime = t
-			} else {
-				log.Printf("WARN: Failed to parse org.opencontainers.image.created annotation '%s' for %s:%s: %v", created, repo, tag, err)
-			}
-		}
-	}
 
 	if configMap != nil {
 		// Extract version from top-level (Helm chart config structure)
@@ -325,8 +312,6 @@ func createComponentFromOCIChart(repo string, tag string, manifestInfo *ociregis
 		component.WithDescription(description),
 		component.WithOwner(componentOwner),
 		component.WithType(componentType),
-		component.WithLatestReleaseTag(chartVersion),
-		component.WithLatestReleaseTime(createdTime),
 		component.WithTags("helmchart"),
 	}
 

--- a/cmd/charts/charts_test.go
+++ b/cmd/charts/charts_test.go
@@ -2,7 +2,6 @@ package charts
 
 import (
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 
@@ -25,10 +24,8 @@ func TestCreateComponentFromOCIChart(t *testing.T) {
 		wantTags              []string
 		wantAnnotations       map[string]string
 		wantLinks             []bscatalog.EntityLink
-		wantVersion           string
 		wantOwner             string
 		wantGithubProjectSlug string
-		wantCreatedTimeSet    bool
 		wantErr               bool
 	}{
 		{
@@ -55,10 +52,8 @@ func TestCreateComponentFromOCIChart(t *testing.T) {
 				"giantswarm.io/helmchart-versions":   "v1.0.0",
 			},
 			wantLinks:             nil,
-			wantVersion:           "v1.0.0",
 			wantOwner:             "group:unspecified",
 			wantGithubProjectSlug: "giantswarm/my-chart-app",
-			wantCreatedTimeSet:    true,
 			wantErr:               false,
 		},
 		{
@@ -90,10 +85,8 @@ func TestCreateComponentFromOCIChart(t *testing.T) {
 				"giantswarm.io/helmchart-app-versions": "1.5.3",
 			},
 			wantLinks:             nil,
-			wantVersion:           "2.1.0",
 			wantOwner:             "group:unspecified",
 			wantGithubProjectSlug: "giantswarm/advanced-chart-app",
-			wantCreatedTimeSet:    true,
 			wantErr:               false,
 		},
 		{
@@ -126,10 +119,8 @@ func TestCreateComponentFromOCIChart(t *testing.T) {
 				"giantswarm.io/icon-url":             "https://example.com/icon.png",
 			},
 			wantLinks:             nil,
-			wantVersion:           "v1.0.0",
 			wantOwner:             "group:team-honeybadger",
 			wantGithubProjectSlug: "giantswarm/chart-with-icon-app",
-			wantCreatedTimeSet:    true,
 			wantErr:               false,
 		},
 		{
@@ -160,10 +151,8 @@ func TestCreateComponentFromOCIChart(t *testing.T) {
 				"giantswarm.io/helmchart-versions":   "v2.0.0",
 			},
 			wantLinks:             nil,
-			wantVersion:           "v2.0.0",
 			wantOwner:             "group:team-atlas",
 			wantGithubProjectSlug: "giantswarm/atlas-chart-app",
-			wantCreatedTimeSet:    true,
 			wantErr:               false,
 		},
 		{
@@ -195,10 +184,8 @@ func TestCreateComponentFromOCIChart(t *testing.T) {
 				"giantswarm.io/helmchart-versions":   "v1.5.0",
 			},
 			wantLinks:             nil,
-			wantVersion:           "v1.5.0",
 			wantOwner:             "group:unspecified",
 			wantGithubProjectSlug: "giantswarm/managed-chart-app",
-			wantCreatedTimeSet:    true,
 			wantErr:               false,
 		},
 		{
@@ -226,10 +213,8 @@ func TestCreateComponentFromOCIChart(t *testing.T) {
 				"giantswarm.io/helmchart-versions":   "v1.0.0",
 			},
 			wantLinks:             nil,
-			wantVersion:           "v1.0.0",
 			wantOwner:             "group:unspecified",
 			wantGithubProjectSlug: "giantswarm/hello-world-app",
-			wantCreatedTimeSet:    true,
 			wantErr:               false,
 		},
 		{
@@ -257,10 +242,8 @@ func TestCreateComponentFromOCIChart(t *testing.T) {
 				"giantswarm.io/helmchart-versions":   "v2.3.100",
 			},
 			wantLinks:             nil,
-			wantVersion:           "v2.3.100",
 			wantOwner:             "group:unspecified",
 			wantGithubProjectSlug: "giantswarm/docs",
-			wantCreatedTimeSet:    true,
 			wantErr:               false,
 		},
 		{
@@ -363,31 +346,9 @@ func TestCreateComponentFromOCIChart(t *testing.T) {
 				t.Errorf("createComponentFromOCIChart() Links mismatch (-want +got):\n%s", diff)
 			}
 
-			// Check version
-			if got.LatestReleaseTag != tt.wantVersion {
-				t.Errorf("createComponentFromOCIChart() LatestReleaseTag = %v, want %v", got.LatestReleaseTag, tt.wantVersion)
-			}
-
 			// Check GitHub project slug
 			if got.GithubProjectSlug != tt.wantGithubProjectSlug {
 				t.Errorf("createComponentFromOCIChart() GithubProjectSlug = %v, want %v", got.GithubProjectSlug, tt.wantGithubProjectSlug)
-			}
-
-			// Check that creation time is set when expected
-			if tt.wantCreatedTimeSet {
-				if got.LatestReleaseTime.IsZero() {
-					t.Errorf("createComponentFromOCIChart() LatestReleaseTime should not be zero")
-				}
-			}
-
-			// For test cases with specific created time from manifest annotations, verify it's parsed correctly
-			if tt.manifestAnnotations != nil {
-				if created, ok := tt.manifestAnnotations["org.opencontainers.image.created"]; ok {
-					expectedTime, _ := time.Parse(time.RFC3339, created)
-					if !got.LatestReleaseTime.Equal(expectedTime) {
-						t.Errorf("createComponentFromOCIChart() LatestReleaseTime = %v, want %v", got.LatestReleaseTime, expectedTime)
-					}
-				}
 			}
 		})
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -178,16 +178,6 @@ func runRoot(cmd *cobra.Command, args []string) {
 				}
 			}
 
-			latestReleaseTime, err := repoService.MustGetLatestReleaseTime(repo.Name)
-			if err != nil {
-				log.Fatalf("Error: %v", err)
-			}
-
-			latestReleaseTag, err := repoService.MustGetLatestReleaseTag(repo.Name)
-			if err != nil {
-				log.Fatalf("Error: %v", err)
-			}
-
 			description := repoService.MustGetDescription(repo.Name)
 			defaultBranch := repoService.MustGetDefaultBranch(repo.Name)
 
@@ -210,11 +200,8 @@ func runRoot(cmd *cobra.Command, args []string) {
 				component.WithGithubProjectSlug(fmt.Sprintf("%s/%s", githubOrganization, repo.Name)),
 				component.WithGithubTeamSlug(list.OwnerTeamName),
 				component.WithHasReadme(hasReadme),
-				component.WithHasReleases(latestReleaseTag != ""),
 				component.WithHelmCharts(charts...),
 				component.WithLanguage(genLanguage),
-				component.WithLatestReleaseTag(latestReleaseTag),
-				component.WithLatestReleaseTime(latestReleaseTime),
 				component.WithLifecycle(string(repo.Lifecycle)),
 				component.WithOwner(list.OwnerTeamName),
 				component.WithPrivate(isPrivate),

--- a/pkg/input/repositories/repositories.go
+++ b/pkg/input/repositories/repositories.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/giantswarm/microerror"
 	"github.com/google/go-github/v86/github"
@@ -52,8 +51,6 @@ type Service struct {
 	githubRepoDetails map[string]GithubRepoDetails
 	// Cached information on repo content
 	githubRepoContentDetails map[string]GithubRepoContentDetails
-	// Cached information on repo releases
-	githubReleaseDetails map[string]GithubReleaseDetails
 }
 
 // New instantiates a new repositories service.
@@ -80,7 +77,6 @@ func New(c Config) (*Service, error) {
 		githubClient:             client,
 		githubRepoDetails:        make(map[string]GithubRepoDetails),
 		githubRepoContentDetails: make(map[string]GithubRepoContentDetails),
-		githubReleaseDetails:     make(map[string]GithubReleaseDetails),
 	}
 
 	if c.GithubAuthToken != "" {
@@ -208,29 +204,6 @@ func (s *Service) LoadGitHubFile(name string, path string) (string, error) {
 	return fileContent.GetContent()
 }
 
-// Load tag and date of the projectz's latest release.
-func (s *Service) loadGithubReleaseDetails(name string) error {
-	latestRelease, response, err := s.githubClient.Repositories.GetLatestRelease(s.ctx, s.config.GithubOrganization, name)
-	if err != nil && response.StatusCode != http.StatusNotFound {
-		return err
-	}
-
-	created := time.Time{}
-	tag := latestRelease.GetTagName()
-	if tag != "" {
-		created = latestRelease.CreatedAt.Time
-	}
-
-	details := GithubReleaseDetails{
-		LatestReleaseTime: created,
-		LatestReleaseTag:  tag,
-	}
-
-	s.githubReleaseDetails[name] = details
-
-	return nil
-}
-
 // Loads a list of repository configurations from a local path.
 // The file name is asserted in the format `<team_name>.yaml`, with all
 // repositories mentioned in it belonging to the team of that name.
@@ -326,32 +299,6 @@ func (s *Service) MustGetDefaultBranch(name string) string {
 	}
 
 	return s.githubRepoDetails[name].DefaultBranch
-}
-
-// Returns the creation time of the repository's most recent release.
-// If no release was found, returns zero-value time.
-func (s *Service) MustGetLatestReleaseTime(name string) (time.Time, error) {
-	if _, ok := s.githubReleaseDetails[name]; !ok {
-		err := s.loadGithubReleaseDetails(name)
-		if err != nil {
-			return time.Time{}, microerror.Mask(err)
-		}
-	}
-
-	return s.githubReleaseDetails[name].LatestReleaseTime, nil
-}
-
-// Returns the tag of the repository's most recent release.
-// If no release was found, returns empty string.
-func (s *Service) MustGetLatestReleaseTag(name string) (string, error) {
-	if _, ok := s.githubReleaseDetails[name]; !ok {
-		err := s.loadGithubReleaseDetails(name)
-		if err != nil {
-			return "string", microerror.Mask(err)
-		}
-	}
-
-	return s.githubReleaseDetails[name].LatestReleaseTag, nil
 }
 
 // Returns whether the repo has a CircleCI configuration.

--- a/pkg/input/repositories/types.go
+++ b/pkg/input/repositories/types.go
@@ -1,7 +1,5 @@
 package repositories
 
-import "time"
-
 // Repo represents an entry in the giantswarm/github repositories YAML data.
 type Repo struct {
 	Name          string           `yaml:"name"`
@@ -79,13 +77,4 @@ type GithubRepoContentDetails struct {
 	NumHelmCharts int
 
 	HelmChartNames []string
-}
-
-// Cache for info on releases of a repo.
-type GithubReleaseDetails struct {
-	// Creation date/time of the latest release.
-	LatestReleaseTime time.Time
-
-	// Tag name of the latest release.
-	LatestReleaseTag string
 }

--- a/pkg/output/catalog/component/component.go
+++ b/pkg/output/catalog/component/component.go
@@ -4,7 +4,6 @@ package component
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/giantswarm/backstage-catalog-importer/pkg/input/helmchart"
 	bscatalog "github.com/giantswarm/backstage-catalog-importer/pkg/output/bscatalog/v1alpha1"
@@ -55,15 +54,6 @@ type Component struct {
 	// Default branch of the component repository
 	DefaultBranch string
 
-	// Time of the latest release of the component
-	LatestReleaseTime time.Time
-
-	// Tag of the latest release of the component
-	LatestReleaseTag string
-
-	// Whether the component has at least one release (used for tags).
-	HasReleases bool
-
 	// Component type. Defaults to "unspecified".
 	Type string
 
@@ -106,12 +96,11 @@ func New(name string, options ...Option) (*Component, error) {
 	}
 
 	c := &Component{
-		Name:        name,
-		Namespace:   "default",
-		Type:        "unspecified",
-		Owner:       "unspecified",
-		Lifecycle:   "production",
-		HasReleases: true,
+		Name:      name,
+		Namespace: "default",
+		Type:      "unspecified",
+		Owner:     "unspecified",
+		Lifecycle: "production",
 	}
 
 	for _, option := range options {

--- a/pkg/output/catalog/component/component_test.go
+++ b/pkg/output/catalog/component/component_test.go
@@ -2,7 +2,6 @@ package component
 
 import (
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 
@@ -77,8 +76,6 @@ func TestComponent_ToEntity(t *testing.T) {
 				WithHasReadme(true),
 				WithKubernetesID("my-k8s-id"),
 				WithLabels(map[string]string{"key": "value"}),
-				WithLatestReleaseTag("v5.0.1"),
-				WithLatestReleaseTime(time.Date(2018, time.January, 3, 1, 2, 3, 0, time.UTC)),
 				WithLifecycle("deprecated"),
 				WithNamespace("my-namespace"),
 				WithOwner("my-owner"),
@@ -106,8 +103,6 @@ func TestComponent_ToEntity(t *testing.T) {
 						"backstage.io/source-location":         "url:https://github.com/foo-org/my-project",
 						"backstage.io/techdocs-ref":            "url:https://github.com/foo-org/my-project/tree/master",
 						"circleci.com/project-slug":            "my-circleci-slug",
-						"giantswarm.io/latest-release-date":    "2018-01-03T01:02:03Z",
-						"giantswarm.io/latest-release-tag":     "v5.0.1",
 						"github.com/project-slug":              "foo-org/my-project",
 						"github.com/team-slug":                 "my-team",
 						"giantswarm.io/helmcharts":             "gsoci.azurecr.io/charts/giantswarm/first-chart,gsoci.azurecr.io/charts/giantswarm/second-chart",
@@ -124,35 +119,6 @@ func TestComponent_ToEntity(t *testing.T) {
 					Owner:     "my-owner",
 					System:    "my-system",
 					DependsOn: []string{"component:first-dependency", "component:second-dependency"},
-				},
-			},
-			wantErr: false,
-		},
-		{
-			name:          "NoReleases",
-			componentName: "no-releases-component",
-			options: []Option{
-				WithHasReleases(false),
-				WithLanguage("python"),
-				WithFlavors("cli"),
-			},
-			want: &bscatalog.Entity{
-				APIVersion: bscatalog.APIVersion,
-				Kind:       bscatalog.EntityKindComponent,
-				Metadata: bscatalog.EntityMetadata{
-					Name: "no-releases-component",
-					Labels: map[string]string{
-						"giantswarm.io/language":   "python",
-						"giantswarm.io/flavor-cli": "true",
-					},
-					Annotations: map[string]string{},
-					Links:       []bscatalog.EntityLink{},
-					Tags:        []string{"flavor:cli", "language:python", "no-releases"},
-				},
-				Spec: bscatalog.ComponentSpec{
-					Type:      "unspecified",
-					Lifecycle: "production",
-					Owner:     "unspecified",
 				},
 			},
 			wantErr: false,
@@ -300,12 +266,11 @@ func TestNew(t *testing.T) {
 			name: "Success",
 			args: args{name: "minimal"},
 			want: &Component{
-				Name:        "minimal",
-				Namespace:   "default",
-				Owner:       "unspecified",
-				Type:        "unspecified",
-				Lifecycle:   "production",
-				HasReleases: true,
+				Name:      "minimal",
+				Namespace: "default",
+				Owner:     "unspecified",
+				Type:      "unspecified",
+				Lifecycle: "production",
 			},
 		},
 		{
@@ -343,12 +308,11 @@ func TestGeneric(t *testing.T) {
 				return New("minimal")
 			},
 			want: &Component{
-				Name:        "minimal",
-				Namespace:   "default",
-				Owner:       "unspecified",
-				Type:        "unspecified",
-				Lifecycle:   "production",
-				HasReleases: true,
+				Name:      "minimal",
+				Namespace: "default",
+				Owner:     "unspecified",
+				Type:      "unspecified",
+				Lifecycle: "production",
 			},
 		},
 		{
@@ -373,12 +337,11 @@ func TestGeneric(t *testing.T) {
 				Links: []bscatalog.EntityLink{
 					{URL: "https://example.com", Title: "link1", Icon: "dashboard", Type: "dashboard"},
 				},
-				Name:        "minimal",
-				Namespace:   "default",
-				Owner:       "unspecified",
-				Tags:        []string{"tag1"},
-				Type:        "unspecified",
-				HasReleases: true,
+				Name:      "minimal",
+				Namespace: "default",
+				Owner:     "unspecified",
+				Tags:      []string{"tag1"},
+				Type:      "unspecified",
 			},
 		},
 	}

--- a/pkg/output/catalog/component/options.go
+++ b/pkg/output/catalog/component/options.go
@@ -1,8 +1,6 @@
 package component
 
 import (
-	"time"
-
 	"github.com/giantswarm/backstage-catalog-importer/pkg/input/helmchart"
 )
 
@@ -54,24 +52,6 @@ func WithHasReadme(hasReadme bool) Option {
 func WithDefaultBranch(defaultBranch string) Option {
 	return func(c *Component) {
 		c.DefaultBranch = defaultBranch
-	}
-}
-
-func WithLatestReleaseTime(latestReleaseTime time.Time) Option {
-	return func(c *Component) {
-		c.LatestReleaseTime = latestReleaseTime
-	}
-}
-
-func WithLatestReleaseTag(latestReleaseTag string) Option {
-	return func(c *Component) {
-		c.LatestReleaseTag = latestReleaseTag
-	}
-}
-
-func WithHasReleases(hasReleases bool) Option {
-	return func(c *Component) {
-		c.HasReleases = hasReleases
 	}
 }
 

--- a/pkg/output/catalog/component/to_entity.go
+++ b/pkg/output/catalog/component/to_entity.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"sort"
 	"strings"
-	"time"
 
 	bscatalog "github.com/giantswarm/backstage-catalog-importer/pkg/output/bscatalog/v1alpha1"
 )
@@ -15,9 +14,6 @@ func (c *Component) ToEntity() *bscatalog.Entity {
 	copy(tags, c.Tags)
 	if c.IsPrivate {
 		tags = append(tags, "private")
-	}
-	if !c.HasReleases {
-		tags = append(tags, "no-releases")
 	}
 	if c.DefaultBranch == "master" {
 		tags = append(tags, "defaultbranch:master")
@@ -98,12 +94,6 @@ func (c *Component) ToEntity() *bscatalog.Entity {
 	}
 	if c.GithubTeamSlug != "" {
 		e.Metadata.Annotations["github.com/team-slug"] = c.GithubTeamSlug
-	}
-	if c.LatestReleaseTag != "" {
-		e.Metadata.Annotations["giantswarm.io/latest-release-tag"] = c.LatestReleaseTag
-	}
-	if c.LatestReleaseTime.Format(time.RFC3339) != "0001-01-01T00:00:00Z" {
-		e.Metadata.Annotations["giantswarm.io/latest-release-date"] = c.LatestReleaseTime.Format(time.RFC3339)
 	}
 	if c.CircleCiSlug != "" {
 		e.Metadata.Annotations["circleci.com/project-slug"] = c.CircleCiSlug

--- a/pkg/output/export/export_test.go
+++ b/pkg/output/export/export_test.go
@@ -76,7 +76,6 @@ func TestServiceOutput(t *testing.T) {
 							"giantswarm.io/helmchart-app-versions": ",2.3.4",
 							"giantswarm.io/helmchart-versions":     "1.2.3,0.4.1",
 							"giantswarm.io/helmcharts":             "first-chart,second-chart",
-							"giantswarm.io/latest-release-tag":     "v1.2.3",
 							"github.com/project-slug":              "giantswarm/my-service",
 							"github.com/team-slug":                 "myorg/team-slug",
 						},

--- a/pkg/output/export/testdata/case01.golden
+++ b/pkg/output/export/testdata/case01.golden
@@ -19,7 +19,6 @@ metadata:
         giantswarm.io/helmchart-app-versions: ',2.3.4'
         giantswarm.io/helmchart-versions: 1.2.3,0.4.1
         giantswarm.io/helmcharts: first-chart,second-chart
-        giantswarm.io/latest-release-tag: v1.2.3
         github.com/project-slug: giantswarm/my-service
         github.com/team-slug: myorg/team-slug
     tags:


### PR DESCRIPTION
### What does this PR do?

Removes the `giantswarm.io/latest-release-tag` and `giantswarm.io/latest-release-date` annotations from exported components in both the **root** and **charts** commands.

As part of this:

- The `no-releases` tag (which was derived from the same data) is no longer emitted.
- The `Component.LatestReleaseTime`, `LatestReleaseTag`, and `HasReleases` fields/options are removed.
- The `MustGetLatestReleaseTag` / `MustGetLatestReleaseTime` / `loadGithubReleaseDetails` methods and the `GithubReleaseDetails` cache are removed from `pkg/input/repositories`.

### What is the effect of this change to users?

- The two annotations and the `no-releases` tag no longer appear on Backstage component entities exported by this importer.
- One fewer GitHub API call per repository during a full export (the `GetLatestRelease` call is gone), so exports should be slightly faster and use less rate-limit budget.

### How does it look like?

`components.yaml` entries will no longer contain lines like:

```yaml
giantswarm.io/latest-release-tag: v1.2.3
giantswarm.io/latest-release-date: 2024-01-03T01:02:03Z
```

…and no `no-releases` entry under `tags`.

### Any background context you can provide?

These annotations are now generated in backstage by a custom entity processor.

### What is needed from the reviewers?

Confirm the annotations are truly unused by any Backstage view / plugin / TechDocs reference before merging.

### Do the docs need to be updated?

Not aware of any docs that reference these annotations — please flag if you know of any.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)