### PR TITLE
chore: silence goconst on test files and dedupe non-test literals

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,10 @@
+version: "2"
+
+linters:
+  exclusions:
+    rules:
+      # Test files often contain repeated literal strings (table-driven test
+      # cases, fixture values). Reporting these as goconst violations is noise.
+      - path: _test\.go
+        linters:
+          - goconst

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add `.golangci.yml` configuration that excludes test files from the `goconst` linter, and replace repeated literal strings in non-test code with named constants.
+
 ### Removed
 
 - Remove `giantswarm.io/latest-release-tag` and `giantswarm.io/latest-release-date` annotations from exported components (root and charts commands). The `no-releases` tag is no longer emitted either.

--- a/cmd/charts/charts.go
+++ b/cmd/charts/charts.go
@@ -54,6 +54,8 @@ const (
 
 	audienceAll        = "all"
 	audienceGiantSwarm = "giantswarm"
+
+	defaultComponentOwner = "group:unspecified"
 )
 
 func init() {
@@ -235,7 +237,7 @@ func createComponentFromOCIChart(repo string, tag string, manifestInfo *ociregis
 	var appVersion string
 	var chartType string
 	var iconURL string
-	componentOwner := "group:unspecified" // Default owner
+	componentOwner := defaultComponentOwner
 
 	// See https://github.com/giantswarm/roadmap/issues/4156#issuecomment-3589340419
 	managed := false

--- a/cmd/installations/installations.go
+++ b/cmd/installations/installations.go
@@ -27,6 +27,11 @@ const (
 	outputFlag = "output"
 
 	awsCloudProviderURLMask = "https://signin.aws.amazon.com/switchrole?account=%s&roleName=%s&displayName=%s"
+
+	providerAWS = "aws"
+
+	iconAWS     = "aws"
+	iconGrafana = "grafana"
 )
 
 func init() {
@@ -149,7 +154,7 @@ func toResourceEntity(ins *installations.Installation) *bscatalog.Entity {
 	}
 
 	// Happa and Grafana link
-	if ins.Provider == "aws" || ins.Provider == "azure" || ins.Provider == "kvm" {
+	if ins.Provider == providerAWS || ins.Provider == "azure" || ins.Provider == "kvm" {
 		// Vintage
 		r.Links = append(r.Links, []bscatalog.EntityLink{
 			{
@@ -159,7 +164,7 @@ func toResourceEntity(ins *installations.Installation) *bscatalog.Entity {
 			}, {
 				URL:   fmt.Sprintf("https://grafana.g8s.%s/", ins.Base),
 				Title: "Grafana",
-				Icon:  "grafana",
+				Icon:  iconGrafana,
 			},
 		}...)
 	} else {
@@ -167,11 +172,11 @@ func toResourceEntity(ins *installations.Installation) *bscatalog.Entity {
 			{
 				URL:   fmt.Sprintf("https://grafana-%s.teleport.giantswarm.io", ins.Codename),
 				Title: "Grafana (via Teleport)",
-				Icon:  "grafana",
+				Icon:  iconGrafana,
 			}, {
 				URL:   fmt.Sprintf("https://grafana.%s.%s/", ins.Codename, ins.Base),
 				Title: "Grafana (customer URL)",
-				Icon:  "grafana",
+				Icon:  iconGrafana,
 			}, {
 				URL:   fmt.Sprintf("https://happa.%s.%s/admin-login", ins.Codename, ins.Base),
 				Title: "Happa",
@@ -190,14 +195,14 @@ func toResourceEntity(ins *installations.Installation) *bscatalog.Entity {
 			r.Links = append(r.Links, bscatalog.EntityLink{
 				URL:   fmt.Sprintf(awsCloudProviderURLMask, ins.Aws.HostCluster.Account, ins.Aws.HostCluster.AdminRoleARN, fmt.Sprintf("%s+management+cluster", ins.Codename)),
 				Title: "AWS Console (management cluster)",
-				Icon:  "aws",
+				Icon:  iconAWS,
 			})
 		}
 		if ins.Aws.GuestCluster.Account != "" && ins.Aws.GuestCluster.AdminRoleARN != "" {
 			r.Links = append(r.Links, bscatalog.EntityLink{
 				URL:   fmt.Sprintf(awsCloudProviderURLMask, ins.Aws.GuestCluster.Account, ins.Aws.GuestCluster.AdminRoleARN, fmt.Sprintf("%s+workload+clusters", ins.Codename)),
 				Title: "AWS Console (workload clusters)",
-				Icon:  "aws",
+				Icon:  iconAWS,
 			})
 		}
 	}

--- a/pkg/input/crdconfig/crdconfig.go
+++ b/pkg/input/crdconfig/crdconfig.go
@@ -10,6 +10,8 @@ import (
 	"go.yaml.in/yaml/v3"
 )
 
+const defaultLifecycle = "production"
+
 // Item represents a single CRD configuration entry.
 type Item struct {
 	// URL is the GitHub URL to the CRD YAML file (required).
@@ -102,6 +104,6 @@ func validateItem(item *Item) error {
 // applyDefaults sets default values for optional fields.
 func applyDefaults(item *Item) {
 	if item.Lifecycle == "" {
-		item.Lifecycle = "production"
+		item.Lifecycle = defaultLifecycle
 	}
 }

--- a/pkg/output/catalog/api/api.go
+++ b/pkg/output/catalog/api/api.go
@@ -8,6 +8,13 @@ import (
 	bscatalog "github.com/giantswarm/backstage-catalog-importer/pkg/output/bscatalog/v1alpha1"
 )
 
+const (
+	defaultNamespace = "default"
+	defaultType      = "crd"
+	defaultLifecycle = "production"
+	defaultOwner     = "unspecified"
+)
+
 // API holds our internal representation of something that we want
 // to export as a Backstage entity of kind "API".
 type API struct {
@@ -61,10 +68,10 @@ func New(name string, options ...Option) (*API, error) {
 
 	a := &API{
 		Name:      name,
-		Namespace: "default",
-		Type:      "crd",
-		Lifecycle: "production",
-		Owner:     "unspecified",
+		Namespace: defaultNamespace,
+		Type:      defaultType,
+		Lifecycle: defaultLifecycle,
+		Owner:     defaultOwner,
 	}
 
 	for _, option := range options {

--- a/pkg/output/catalog/api/to_entity.go
+++ b/pkg/output/catalog/api/to_entity.go
@@ -21,7 +21,7 @@ func (a *API) ToEntity() *bscatalog.Entity {
 	}
 
 	// Only set namespace if not "default"
-	if a.Namespace != "default" {
+	if a.Namespace != defaultNamespace {
 		e.Metadata.Namespace = a.Namespace
 	}
 

--- a/pkg/output/catalog/component/component.go
+++ b/pkg/output/catalog/component/component.go
@@ -9,6 +9,15 @@ import (
 	bscatalog "github.com/giantswarm/backstage-catalog-importer/pkg/output/bscatalog/v1alpha1"
 )
 
+const (
+	defaultNamespace = "default"
+	defaultType      = "unspecified"
+	defaultOwner     = "unspecified"
+	defaultLifecycle = "production"
+
+	typeService = "service"
+)
+
 // Component holds our internal representation of something that we want
 // to export as a Backstage entity of type "component".
 type Component struct {
@@ -97,10 +106,10 @@ func New(name string, options ...Option) (*Component, error) {
 
 	c := &Component{
 		Name:      name,
-		Namespace: "default",
-		Type:      "unspecified",
-		Owner:     "unspecified",
-		Lifecycle: "production",
+		Namespace: defaultNamespace,
+		Type:      defaultType,
+		Owner:     defaultOwner,
+		Lifecycle: defaultLifecycle,
 	}
 
 	for _, option := range options {

--- a/pkg/output/catalog/component/to_entity.go
+++ b/pkg/output/catalog/component/to_entity.go
@@ -39,7 +39,7 @@ func (c *Component) ToEntity() *bscatalog.Entity {
 		},
 	}
 
-	if c.Namespace != "default" {
+	if c.Namespace != defaultNamespace {
 		e.Metadata.Namespace = c.Namespace
 	}
 
@@ -98,7 +98,7 @@ func (c *Component) ToEntity() *bscatalog.Entity {
 	if c.CircleCiSlug != "" {
 		e.Metadata.Annotations["circleci.com/project-slug"] = c.CircleCiSlug
 	}
-	if c.Type == "service" {
+	if c.Type == typeService {
 		e.Metadata.Annotations["backstage.io/kubernetes-id"] = c.Name
 		if c.KubernetesID != "" {
 			e.Metadata.Annotations["backstage.io/kubernetes-id"] = c.KubernetesID

--- a/pkg/output/catalog/group/group.go
+++ b/pkg/output/catalog/group/group.go
@@ -7,6 +7,8 @@ import (
 	bscatalog "github.com/giantswarm/backstage-catalog-importer/pkg/output/bscatalog/v1alpha1"
 )
 
+const defaultGroupType = "team"
+
 // Option is an option to configure a Group.
 type Option func(*Group)
 
@@ -39,7 +41,7 @@ func New(name string, options ...Option) (*Group, error) {
 	c := &Group{
 		Name:      name,
 		Namespace: "default",
-		Type:      "team",
+		Type:      defaultGroupType,
 	}
 
 	for _, option := range options {
@@ -66,7 +68,7 @@ func (c *Group) ToEntity() *bscatalog.Entity {
 	}
 
 	e := &bscatalog.Entity{
-		APIVersion: "backstage.io/v1alpha1",
+		APIVersion: bscatalog.APIVersion,
 		Kind:       bscatalog.EntityKindGroup,
 		Metadata: bscatalog.EntityMetadata{
 			Name:        c.Name,

--- a/pkg/output/catalog/user/user.go
+++ b/pkg/output/catalog/user/user.go
@@ -73,7 +73,7 @@ func (c *User) ToEntity() *bscatalog.Entity {
 	}
 
 	e := &bscatalog.Entity{
-		APIVersion: "backstage.io/v1alpha1",
+		APIVersion: bscatalog.APIVersion,
 		Kind:       bscatalog.EntityKindUser,
 		Metadata: bscatalog.EntityMetadata{
 			Name:        c.Name,


### PR DESCRIPTION
### What does this PR do?

Two coordinated changes to clean up `goconst` linter output:

1. **Add `.golangci.yml`** — a minimal v2 config that excludes `_test.go` files from the `goconst` linter. Table-driven tests naturally repeat fixture strings (status values, default namespaces, registry hostnames…) and flagging them adds no signal.
2. **Replace repeated literals in non-test code with named constants** — e.g. `defaultNamespace = \"default\"`, `defaultLifecycle = \"production\"`, `defaultOwner = \"unspecified\"`, `iconAWS`, `iconGrafana`, `providerAWS`, `defaultGroupType`, `defaultComponentOwner`, and reuse of the existing `bscatalog.APIVersion` constant in the group and user catalog code.

Before: `pre-commit run -a` reported 72 `goconst` issues (17 in production code, 55 in tests). After: clean.

### What is the effect of this change to users?

None — no runtime behavior change. Internal refactor only.

### How does it look like?

```
$ pre-commit run -a
…
golangci-lint............................................................Passed
go imports...............................................................Passed
```

### Any background context you can provide?

Triggered by `pre-commit run -a` showing 72 goconst hits.

### What is needed from the reviewers?

Sanity check on the new constant names and the exclusion rule.

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)