### PR TITLE
fix(charts): only use pure semver releases for version annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Release binaries now include darwin/amd64, darwin/arm64, windows/amd64, and windows/arm64 alongside the existing linux targets. Windows binaries are named `backstage-catalog-importer-windows-<arch>.exe`.
 
+### Fixed
+
+- The `charts` command now selects the latest pure semver release when generating the `giantswarm.io/helmchart-versions` and `giantswarm.io/helmchart-app-versions` annotations, ignoring dev/pre-release builds (e.g. `1.1.22-dev....`). Charts that only have dev builds are still exported but without these version annotations.
+
 ## [0.29.0] - 2026-05-13
 
 ### Changed

--- a/cmd/charts/charts.go
+++ b/cmd/charts/charts.go
@@ -141,9 +141,15 @@ func runCharts(cmd *cobra.Command, args []string) {
 			continue
 		}
 
-		// Use the first tag (typically latest or most recent)
-		tag := tags[0]
-		log.Printf("Using tag: %s", tag)
+		// Select the latest pure semver release tag. Dev builds (semver
+		// pre-releases like 1.1.22-dev....) and non-semver tags are ignored.
+		tag, hasRelease := ociregistry.LatestReleaseTag(tags)
+		if hasRelease {
+			log.Printf("Using release tag: %s", tag)
+		} else {
+			tag = tags[0]
+			log.Printf("No pure semver release tag found for %s; using %s for metadata, omitting version annotations", repo, tag)
+		}
 
 		// Get manifest for metadata extraction
 		manifestInfo, err := registry.GetRepositoryManifest(ctx, repo, tag)
@@ -159,7 +165,7 @@ func runCharts(cmd *cobra.Command, args []string) {
 		}
 
 		// Create component from repository and manifest data
-		comp, err := createComponentFromOCIChart(repo, tag, manifestInfo, namespace, componentType, registryHostname)
+		comp, err := createComponentFromOCIChart(repo, tag, manifestInfo, namespace, componentType, registryHostname, hasRelease)
 		if err != nil {
 			log.Printf("WARN: Failed to create component for %s:%s: %v", repo, tag, err)
 			continue
@@ -192,7 +198,7 @@ func runCharts(cmd *cobra.Command, args []string) {
 }
 
 // createComponentFromOCIChart creates a Backstage component from OCI chart metadata
-func createComponentFromOCIChart(repo string, tag string, manifestInfo *ociregistry.ManifestInfo, namespace, componentType, registryHostname string) (*component.Component, error) {
+func createComponentFromOCIChart(repo string, tag string, manifestInfo *ociregistry.ManifestInfo, namespace, componentType, registryHostname string, setVersions bool) (*component.Component, error) {
 	configMap := manifestInfo.Config
 
 	// Extract GitHub project slug and repository name from home field (Helm chart config structure)
@@ -336,11 +342,17 @@ func createComponentFromOCIChart(repo string, tag string, manifestInfo *ociregis
 	// Format: registry/repository (combining what was oci-registry and oci-repository)
 	helmchartPath := fmt.Sprintf("%s/%s", registryHostname, repo)
 	comp.SetAnnotation("giantswarm.io/helmcharts", helmchartPath)
-	comp.SetAnnotation("giantswarm.io/helmchart-versions", chartVersion)
 
-	// Add app version if available
-	if appVersion != "" {
-		comp.SetAnnotation("giantswarm.io/helmchart-app-versions", appVersion)
+	// Only set version annotations when the selected tag is a pure semver
+	// release. For charts that only have dev/pre-release tags, we still export
+	// the component but omit the version annotations.
+	if setVersions {
+		comp.SetAnnotation("giantswarm.io/helmchart-versions", chartVersion)
+
+		// Add app version if available
+		if appVersion != "" {
+			comp.SetAnnotation("giantswarm.io/helmchart-app-versions", appVersion)
+		}
 	}
 
 	// Add audience and managed annotations

--- a/cmd/charts/charts.go
+++ b/cmd/charts/charts.go
@@ -141,8 +141,11 @@ func runCharts(cmd *cobra.Command, args []string) {
 			continue
 		}
 
-		// Select the latest pure semver release tag. Dev builds (semver
-		// pre-releases like 1.1.22-dev....) and non-semver tags are ignored.
+		// Prefer the latest pure semver release tag for metadata extraction,
+		// so the component reflects the latest release rather than a dev build.
+		// Dev builds (semver pre-releases like 1.1.22-dev....) and non-semver
+		// tags fall back to the highest tag; the version annotations are gated
+		// separately in createComponentFromOCIChart.
 		tag, hasRelease := ociregistry.LatestReleaseTag(tags)
 		if hasRelease {
 			log.Printf("Using release tag: %s", tag)
@@ -165,7 +168,7 @@ func runCharts(cmd *cobra.Command, args []string) {
 		}
 
 		// Create component from repository and manifest data
-		comp, err := createComponentFromOCIChart(repo, tag, manifestInfo, namespace, componentType, registryHostname, hasRelease)
+		comp, err := createComponentFromOCIChart(repo, tag, manifestInfo, namespace, componentType, registryHostname)
 		if err != nil {
 			log.Printf("WARN: Failed to create component for %s:%s: %v", repo, tag, err)
 			continue
@@ -198,7 +201,7 @@ func runCharts(cmd *cobra.Command, args []string) {
 }
 
 // createComponentFromOCIChart creates a Backstage component from OCI chart metadata
-func createComponentFromOCIChart(repo string, tag string, manifestInfo *ociregistry.ManifestInfo, namespace, componentType, registryHostname string, setVersions bool) (*component.Component, error) {
+func createComponentFromOCIChart(repo string, tag string, manifestInfo *ociregistry.ManifestInfo, namespace, componentType, registryHostname string) (*component.Component, error) {
 	configMap := manifestInfo.Config
 
 	// Extract GitHub project slug and repository name from home field (Helm chart config structure)
@@ -343,10 +346,11 @@ func createComponentFromOCIChart(repo string, tag string, manifestInfo *ociregis
 	helmchartPath := fmt.Sprintf("%s/%s", registryHostname, repo)
 	comp.SetAnnotation("giantswarm.io/helmcharts", helmchartPath)
 
-	// Only set version annotations when the selected tag is a pure semver
-	// release. For charts that only have dev/pre-release tags, we still export
-	// the component but omit the version annotations.
-	if setVersions {
+	// Only publish version annotations for pure semver releases. chartVersion
+	// comes from the chart's config (Chart.yaml version), falling back to the
+	// tag; we validate the value actually written rather than just the selected
+	// tag, so dev/pre-release builds never end up in the annotations.
+	if ociregistry.IsReleaseVersion(chartVersion) {
 		comp.SetAnnotation("giantswarm.io/helmchart-versions", chartVersion)
 
 		// Add app version if available

--- a/cmd/charts/charts_test.go
+++ b/cmd/charts/charts_test.go
@@ -299,7 +299,6 @@ func TestCreateComponentFromOCIChart(t *testing.T) {
 				tt.namespace,
 				tt.componentType,
 				tt.registryHostname,
-				true,
 			)
 
 			if (err != nil) != tt.wantErr {
@@ -355,41 +354,66 @@ func TestCreateComponentFromOCIChart(t *testing.T) {
 	}
 }
 
-// TestCreateComponentFromOCIChart_OmitVersions verifies that when setVersions is
-// false (no pure semver release tag available), the component is still created but
-// the version annotations are omitted while the helmcharts path annotation remains.
+// TestCreateComponentFromOCIChart_OmitVersions verifies that when the resolved
+// chart version is not a pure semver release, the component is still created but
+// the version annotations are omitted while the helmcharts path annotation
+// remains. Both the dev-tag case and the case where the tag is a clean release
+// but the config version carries a pre-release suffix are covered.
 func TestCreateComponentFromOCIChart_OmitVersions(t *testing.T) {
-	manifestInfo := &ociregistry.ManifestInfo{
-		Config: map[string]interface{}{
-			"description": "Dev-only chart",
-			"version":     "1.1.22-dev.teams-alignment-branch.2026-06-10.19-12-31.h10c664f",
-			"appVersion":  "1.1.22-dev",
-			"home":        "https://github.com/giantswarm/dev-chart-app",
+	tests := []struct {
+		name      string
+		tag       string
+		configMap map[string]interface{}
+	}{
+		{
+			name: "Dev tag and dev config version",
+			tag:  "1.1.22-dev.teams-alignment-branch.2026-06-10.19-12-31.h10c664f",
+			configMap: map[string]interface{}{
+				"description": "Dev-only chart",
+				"version":     "1.1.22-dev.teams-alignment-branch.2026-06-10.19-12-31.h10c664f",
+				"appVersion":  "1.1.22-dev",
+				"home":        "https://github.com/giantswarm/dev-chart-app",
+			},
+		},
+		{
+			name: "Clean tag but pre-release config version",
+			tag:  "1.1.22",
+			configMap: map[string]interface{}{
+				"description": "Chart with dirty config version",
+				"version":     "1.1.22-dev.teams-alignment-branch.2026-06-10.19-12-31.h10c664f",
+				"appVersion":  "1.1.22-dev",
+				"home":        "https://github.com/giantswarm/dev-chart-app",
+			},
 		},
 	}
 
-	got, err := createComponentFromOCIChart(
-		"giantswarm/dev-chart",
-		"1.1.22-dev.teams-alignment-branch.2026-06-10.19-12-31.h10c664f",
-		manifestInfo,
-		"default",
-		"service",
-		"registry.example.com",
-		false,
-	)
-	if err != nil {
-		t.Fatalf("createComponentFromOCIChart() unexpected error: %v", err)
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manifestInfo := &ociregistry.ManifestInfo{Config: tt.configMap}
 
-	wantAnnotations := map[string]string{
-		"application.giantswarm.io/audience": "all",
-		"application.giantswarm.io/managed":  "false",
-		"backstage.io/techdocs-ref":          "url:https://github.com/giantswarm/dev-chart-app/tree/main",
-		"giantswarm.io/helmcharts":           "registry.example.com/giantswarm/dev-chart",
-	}
+			got, err := createComponentFromOCIChart(
+				"giantswarm/dev-chart",
+				tt.tag,
+				manifestInfo,
+				"default",
+				"service",
+				"registry.example.com",
+			)
+			if err != nil {
+				t.Fatalf("createComponentFromOCIChart() unexpected error: %v", err)
+			}
 
-	if diff := cmp.Diff(wantAnnotations, got.Annotations); diff != "" {
-		t.Errorf("createComponentFromOCIChart() Annotations mismatch (-want +got):\n%s", diff)
+			wantAnnotations := map[string]string{
+				"application.giantswarm.io/audience": "all",
+				"application.giantswarm.io/managed":  "false",
+				"backstage.io/techdocs-ref":          "url:https://github.com/giantswarm/dev-chart-app/tree/main",
+				"giantswarm.io/helmcharts":           "registry.example.com/giantswarm/dev-chart",
+			}
+
+			if diff := cmp.Diff(wantAnnotations, got.Annotations); diff != "" {
+				t.Errorf("createComponentFromOCIChart() Annotations mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
 }
 
@@ -471,7 +495,6 @@ func TestCreateComponentFromOCIChart_ErrorCases(t *testing.T) {
 				tt.namespace,
 				tt.componentType,
 				tt.registryHostname,
-				true,
 			)
 
 			if (err != nil) != tt.wantErr {

--- a/cmd/charts/charts_test.go
+++ b/cmd/charts/charts_test.go
@@ -299,6 +299,7 @@ func TestCreateComponentFromOCIChart(t *testing.T) {
 				tt.namespace,
 				tt.componentType,
 				tt.registryHostname,
+				true,
 			)
 
 			if (err != nil) != tt.wantErr {
@@ -351,6 +352,44 @@ func TestCreateComponentFromOCIChart(t *testing.T) {
 				t.Errorf("createComponentFromOCIChart() GithubProjectSlug = %v, want %v", got.GithubProjectSlug, tt.wantGithubProjectSlug)
 			}
 		})
+	}
+}
+
+// TestCreateComponentFromOCIChart_OmitVersions verifies that when setVersions is
+// false (no pure semver release tag available), the component is still created but
+// the version annotations are omitted while the helmcharts path annotation remains.
+func TestCreateComponentFromOCIChart_OmitVersions(t *testing.T) {
+	manifestInfo := &ociregistry.ManifestInfo{
+		Config: map[string]interface{}{
+			"description": "Dev-only chart",
+			"version":     "1.1.22-dev.teams-alignment-branch.2026-06-10.19-12-31.h10c664f",
+			"appVersion":  "1.1.22-dev",
+			"home":        "https://github.com/giantswarm/dev-chart-app",
+		},
+	}
+
+	got, err := createComponentFromOCIChart(
+		"giantswarm/dev-chart",
+		"1.1.22-dev.teams-alignment-branch.2026-06-10.19-12-31.h10c664f",
+		manifestInfo,
+		"default",
+		"service",
+		"registry.example.com",
+		false,
+	)
+	if err != nil {
+		t.Fatalf("createComponentFromOCIChart() unexpected error: %v", err)
+	}
+
+	wantAnnotations := map[string]string{
+		"application.giantswarm.io/audience": "all",
+		"application.giantswarm.io/managed":  "false",
+		"backstage.io/techdocs-ref":          "url:https://github.com/giantswarm/dev-chart-app/tree/main",
+		"giantswarm.io/helmcharts":           "registry.example.com/giantswarm/dev-chart",
+	}
+
+	if diff := cmp.Diff(wantAnnotations, got.Annotations); diff != "" {
+		t.Errorf("createComponentFromOCIChart() Annotations mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -432,6 +471,7 @@ func TestCreateComponentFromOCIChart_ErrorCases(t *testing.T) {
 				tt.namespace,
 				tt.componentType,
 				tt.registryHostname,
+				true,
 			)
 
 			if (err != nil) != tt.wantErr {

--- a/pkg/input/ociregistry/ociregistry.go
+++ b/pkg/input/ociregistry/ociregistry.go
@@ -129,17 +129,25 @@ func sortTagsBySemver(tags []string) {
 	})
 }
 
-// LatestReleaseTag returns the first tag that parses as a valid semver release
-// without a pre-release component. Tags are expected to be sorted descending
-// (as returned by ListRepositoryTags), so the first qualifying tag is the
-// highest release. Returns "" and false if no tag qualifies.
+// IsReleaseVersion reports whether version is a valid semver release without a
+// pre-release component. Dev builds like
+// "1.1.22-dev.teams-alignment-branch.2026-06-10.19-12-31.h10c664f" and
+// non-semver values return false.
+func IsReleaseVersion(version string) bool {
+	v, err := semver.NewVersion(version)
+	if err != nil {
+		return false
+	}
+	return v.Prerelease() == ""
+}
+
+// LatestReleaseTag returns the first tag that is a pure semver release (see
+// IsReleaseVersion). Tags are expected to be sorted descending (as returned by
+// ListRepositoryTags), so the first qualifying tag is the highest release.
+// Returns "" and false if no tag qualifies.
 func LatestReleaseTag(tags []string) (string, bool) {
 	for _, tag := range tags {
-		v, err := semver.NewVersion(tag)
-		if err != nil {
-			continue
-		}
-		if v.Prerelease() == "" {
+		if IsReleaseVersion(tag) {
 			return tag, true
 		}
 	}

--- a/pkg/input/ociregistry/ociregistry.go
+++ b/pkg/input/ociregistry/ociregistry.go
@@ -129,6 +129,23 @@ func sortTagsBySemver(tags []string) {
 	})
 }
 
+// LatestReleaseTag returns the first tag that parses as a valid semver release
+// without a pre-release component. Tags are expected to be sorted descending
+// (as returned by ListRepositoryTags), so the first qualifying tag is the
+// highest release. Returns "" and false if no tag qualifies.
+func LatestReleaseTag(tags []string) (string, bool) {
+	for _, tag := range tags {
+		v, err := semver.NewVersion(tag)
+		if err != nil {
+			continue
+		}
+		if v.Prerelease() == "" {
+			return tag, true
+		}
+	}
+	return "", false
+}
+
 // ManifestInfo contains both the config and manifest annotations
 type ManifestInfo struct {
 	Config      map[string]interface{}

--- a/pkg/input/ociregistry/ociregistry_test.go
+++ b/pkg/input/ociregistry/ociregistry_test.go
@@ -198,3 +198,64 @@ func TestSortTagsBySemver(t *testing.T) {
 		})
 	}
 }
+
+func TestLatestReleaseTag(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   []string
+		wantTag string
+		wantOK  bool
+	}{
+		{
+			name:    "Dev build sorts above release but is skipped",
+			input:   []string{"1.1.22-dev.teams-alignment-branch.2026-06-10.19-12-31.h10c664f", "1.1.21", "1.1.20"},
+			wantTag: "1.1.21",
+			wantOK:  true,
+		},
+		{
+			name:    "Plain releases return the highest",
+			input:   []string{"2.0.0", "1.5.0", "1.0.0"},
+			wantTag: "2.0.0",
+			wantOK:  true,
+		},
+		{
+			name:    "v-prefixed releases",
+			input:   []string{"v2.0.0", "v1.0.0"},
+			wantTag: "v2.0.0",
+			wantOK:  true,
+		},
+		{
+			name:    "Only pre-releases yields no release",
+			input:   []string{"1.0.0-rc1", "1.0.0-beta", "1.0.0-alpha"},
+			wantTag: "",
+			wantOK:  false,
+		},
+		{
+			name:    "Non-semver tags are skipped",
+			input:   []string{"latest", "main", "1.2.3"},
+			wantTag: "1.2.3",
+			wantOK:  true,
+		},
+		{
+			name:    "All non-semver tags yields no release",
+			input:   []string{"latest", "main", "dev"},
+			wantTag: "",
+			wantOK:  false,
+		},
+		{
+			name:    "Empty slice yields no release",
+			input:   []string{},
+			wantTag: "",
+			wantOK:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotTag, gotOK := LatestReleaseTag(tt.input)
+			if gotTag != tt.wantTag || gotOK != tt.wantOK {
+				t.Errorf("LatestReleaseTag() = (%q, %v), want (%q, %v)", gotTag, gotOK, tt.wantTag, tt.wantOK)
+			}
+		})
+	}
+}

--- a/pkg/input/ociregistry/ociregistry_test.go
+++ b/pkg/input/ociregistry/ociregistry_test.go
@@ -199,6 +199,28 @@ func TestSortTagsBySemver(t *testing.T) {
 	}
 }
 
+func TestIsReleaseVersion(t *testing.T) {
+	tests := []struct {
+		version string
+		want    bool
+	}{
+		{"1.1.21", true},
+		{"v2.0.0", true},
+		{"1.1.22-dev.teams-alignment-branch.2026-06-10.19-12-31.h10c664f", false},
+		{"1.0.0-alpha", false},
+		{"latest", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			if got := IsReleaseVersion(tt.version); got != tt.want {
+				t.Errorf("IsReleaseVersion(%q) = %v, want %v", tt.version, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestLatestReleaseTag(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
### What does this PR do?

The `charts` command generates the `giantswarm.io/helmchart-versions` and `giantswarm.io/helmchart-app-versions` annotations from the highest tag of each chart's OCI repository. Dev builds like `1.1.22-dev.teams-alignment-branch.2026-06-10.19-12-31.h10c664f` are valid semver pre-releases and sort *above* a pure release like `1.1.21`, so the annotations ended up pointing at dev builds.

This adds `ociregistry.LatestReleaseTag`, which returns the highest tag that parses as semver with no pre-release component, and uses it when selecting the chart tag. Charts whose repository only contains dev/pre-release tags are still exported, but without the two version annotations.

### What is the effect of this change to users?

Exported catalog components now show real releases (e.g. `1.1.21`) in their helmchart version annotations instead of dev builds.

### How does it look like?

Before: `giantswarm.io/helmchart-versions: 1.1.22-dev.teams-alignment-branch.2026-06-10.19-12-31.h10c664f`
After: `giantswarm.io/helmchart-versions: 1.1.21`

### Any background context you can provide?

Caused entries like those in https://github.com/giantswarm/backstage-catalogs/pull/582.

### What is needed from the reviewers?

Sanity check on the edge-case behavior: charts with only dev tags are exported without version annotations (rather than skipped).

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)