### PR TITLE
feat: add groups subcommand and remove group export from root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add a `groups` subcommand that exports Giant Swarm GitHub teams as Backstage group entities to `groups.yaml`.
+
+### Removed
+
+- Remove group (`groups.yaml`) generation from the root command. Use the new `groups` subcommand instead.
+
 ## [0.29.1] - 2026-06-11
 
 ### Changed

--- a/cmd/groups/groups.go
+++ b/cmd/groups/groups.go
@@ -1,0 +1,103 @@
+// Provides the 'groups' command to export Giant Swarm GitHub teams as Backstage group entities.
+package groups
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/google/go-github/v88/github"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/backstage-catalog-importer/pkg/input/teams"
+	"github.com/giantswarm/backstage-catalog-importer/pkg/output/catalog/group"
+	"github.com/giantswarm/backstage-catalog-importer/pkg/output/export"
+)
+
+// Name of the GitHub organization owning our teams and users.
+const githubOrganization = "giantswarm"
+
+var Command = &cobra.Command{
+	Use:   "groups",
+	Short: "Export groups catalog",
+	Long:  `Exports Giant Swarm GitHub teams as Backstage group entities.`,
+	RunE:  run,
+}
+
+func run(cmd *cobra.Command, args []string) error {
+	token := os.Getenv("GITHUB_TOKEN")
+	if token == "" {
+		log.Fatal("Please set environment variable GITHUB_TOKEN to a personal GitHub access token (PAT).")
+	}
+
+	path, err := cmd.Root().PersistentFlags().GetString("output")
+	if err != nil {
+		log.Fatalf("Error: could not access 'output' flag - %s", err)
+	}
+
+	teamsService, err := teams.New(teams.Config{
+		GithubOrganization: githubOrganization,
+		GithubAuthToken:    token,
+	})
+	if err != nil {
+		log.Fatalf("Error: could not create teams service -- %v", err)
+	}
+
+	groupExporter := export.New(export.Config{TargetPath: path + "/groups.yaml"})
+
+	teamsList, err := teamsService.GetAll()
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	log.Printf("Processing %d teams", len(teamsList))
+
+	numGroups := 0
+	for _, team := range teamsList {
+		members, err := teamsService.GetMembers(team.GetSlug())
+		if err != nil {
+			log.Fatalf("Error: %v", err)
+		}
+
+		var memberNames []string
+		for _, u := range members {
+			memberNames = append(memberNames, u.GetLogin())
+		}
+
+		g, err := groupFromTeam(team, memberNames)
+		if err != nil {
+			log.Fatalf("Error: could not create group -- %v", err)
+		}
+
+		err = groupExporter.AddEntity(g.ToEntity())
+		if err != nil {
+			log.Fatalf("Error: %v", err)
+		}
+		numGroups++
+	}
+
+	err = groupExporter.WriteFile()
+	if err != nil {
+		log.Fatalf("Error writing groups: %v", err)
+	}
+
+	fmt.Printf("\n%d groups written to file %s with size %d bytes\n", numGroups, groupExporter.TargetPath, groupExporter.Len())
+
+	return nil
+}
+
+// groupFromTeam builds a Backstage group from a GitHub team and its member logins.
+func groupFromTeam(team *github.Team, memberNames []string) (*group.Group, error) {
+	parentTeamName := ""
+	if team.GetParent() != nil {
+		parentTeamName = team.GetParent().GetSlug()
+	}
+
+	return group.New(team.GetSlug(),
+		group.WithTitle(team.GetName()),
+		group.WithDescription(team.GetDescription()),
+		group.WithPictureURL(fmt.Sprintf("https://avatars.githubusercontent.com/t/%d?s=116&v=4", team.GetID())),
+		group.WithMemberNames(memberNames...),
+		group.WithParentName(parentTeamName),
+		group.WithGrafanaDashboardSelector(fmt.Sprintf("tags @> 'owner:%s'", team.GetSlug())),
+	)
+}

--- a/cmd/groups/groups_test.go
+++ b/cmd/groups/groups_test.go
@@ -1,0 +1,93 @@
+package groups
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/google/go-github/v88/github"
+)
+
+func TestGroupFromTeam(t *testing.T) {
+	testCases := []struct {
+		name        string
+		team        *github.Team
+		memberNames []string
+
+		expectedName     string
+		expectedTitle    string
+		expectedDesc     string
+		expectedPicture  string
+		expectedParent   string
+		expectedSelector string
+		expectedMembers  []string
+	}{
+		{
+			name: "team without parent and with members",
+			team: &github.Team{
+				ID:          github.Ptr(int64(123)),
+				Slug:        github.Ptr("team-honeybadger"),
+				Name:        github.Ptr("Honey Badger"),
+				Description: github.Ptr("The honey badger team"),
+			},
+			memberNames:      []string{"bob", "alice"},
+			expectedName:     "team-honeybadger",
+			expectedTitle:    "Honey Badger",
+			expectedDesc:     "The honey badger team",
+			expectedPicture:  "https://avatars.githubusercontent.com/t/123?s=116&v=4",
+			expectedParent:   "",
+			expectedSelector: "tags @> 'owner:team-honeybadger'",
+			expectedMembers:  []string{"bob", "alice"},
+		},
+		{
+			name: "team with parent and no members",
+			team: &github.Team{
+				ID:          github.Ptr(int64(456)),
+				Slug:        github.Ptr("team-bumblebee"),
+				Name:        github.Ptr("Bumblebee"),
+				Description: github.Ptr(""),
+				Parent: &github.Team{
+					Slug: github.Ptr("team-parent"),
+				},
+			},
+			memberNames:      nil,
+			expectedName:     "team-bumblebee",
+			expectedTitle:    "Bumblebee",
+			expectedDesc:     "",
+			expectedPicture:  "https://avatars.githubusercontent.com/t/456?s=116&v=4",
+			expectedParent:   "team-parent",
+			expectedSelector: "tags @> 'owner:team-bumblebee'",
+			expectedMembers:  nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g, err := groupFromTeam(tc.team, tc.memberNames)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if g.Name != tc.expectedName {
+				t.Errorf("Name: got %q, want %q", g.Name, tc.expectedName)
+			}
+			if g.Title != tc.expectedTitle {
+				t.Errorf("Title: got %q, want %q", g.Title, tc.expectedTitle)
+			}
+			if g.Description != tc.expectedDesc {
+				t.Errorf("Description: got %q, want %q", g.Description, tc.expectedDesc)
+			}
+			if g.PictureURL != tc.expectedPicture {
+				t.Errorf("PictureURL: got %q, want %q", g.PictureURL, tc.expectedPicture)
+			}
+			if g.ParentName != tc.expectedParent {
+				t.Errorf("ParentName: got %q, want %q", g.ParentName, tc.expectedParent)
+			}
+			if g.GrafanaDashboardSelector != tc.expectedSelector {
+				t.Errorf("GrafanaDashboardSelector: got %q, want %q", g.GrafanaDashboardSelector, tc.expectedSelector)
+			}
+			if !reflect.DeepEqual(g.MemberNames, tc.expectedMembers) {
+				t.Errorf("MemberNames: got %v, want %v", g.MemberNames, tc.expectedMembers)
+			}
+		})
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,14 +11,13 @@ import (
 
 	"github.com/giantswarm/backstage-catalog-importer/cmd/charts"
 	"github.com/giantswarm/backstage-catalog-importer/cmd/crd"
+	groups "github.com/giantswarm/backstage-catalog-importer/cmd/groups"
 	installations "github.com/giantswarm/backstage-catalog-importer/cmd/installations"
 	users "github.com/giantswarm/backstage-catalog-importer/cmd/users"
 	"github.com/giantswarm/backstage-catalog-importer/pkg/input/helmchart"
 	"github.com/giantswarm/backstage-catalog-importer/pkg/input/repositories"
-	"github.com/giantswarm/backstage-catalog-importer/pkg/input/teams"
 	bscatalog "github.com/giantswarm/backstage-catalog-importer/pkg/output/bscatalog/v1alpha1"
 	"github.com/giantswarm/backstage-catalog-importer/pkg/output/catalog/component"
-	"github.com/giantswarm/backstage-catalog-importer/pkg/output/catalog/group"
 	"github.com/giantswarm/backstage-catalog-importer/pkg/output/export"
 	componentutil "github.com/giantswarm/backstage-catalog-importer/pkg/util/component"
 )
@@ -51,6 +50,7 @@ func init() {
 
 	rootCmd.AddCommand(charts.Command)
 	rootCmd.AddCommand(crd.Command)
+	rootCmd.AddCommand(groups.Command)
 	rootCmd.AddCommand(installations.Command)
 	rootCmd.AddCommand(users.Command)
 }
@@ -101,24 +101,14 @@ func runRoot(cmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 
-	teamsService, err := teams.New(teams.Config{
-		GithubOrganization: githubOrganization,
-		GithubAuthToken:    token,
-	})
-	if err != nil {
-		log.Fatal(err)
-	}
-
 	lists, err := repoService.GetLists()
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	groupExporter := export.New(export.Config{TargetPath: path + "/groups.yaml"})
 	componentExporter := export.New(export.Config{TargetPath: path + "/components.yaml"})
 
 	numComponents := 0
-	numGroups := 0
 
 	// Iterate repository lists (per team) and create component entities.
 	for _, list := range lists {
@@ -263,61 +253,12 @@ func runRoot(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	// Export teams
-	teams, err := teamsService.GetAll()
-	if err != nil {
-		log.Fatalf("Error: %v", err)
-	}
-	log.Printf("Processing %d teams", len(teams))
-
-	for _, team := range teams {
-		members, err := teamsService.GetMembers(team.GetSlug())
-		if err != nil {
-			log.Fatalf("Error: %v", err)
-		}
-
-		var memberNames []string
-		for _, u := range members {
-			n := u.GetLogin()
-			memberNames = append(memberNames, n)
-		}
-
-		parentTeamName := ""
-		if team.GetParent() != nil {
-			parentTeamName = team.GetParent().GetSlug()
-		}
-
-		group, err := group.New(team.GetSlug(),
-			group.WithTitle(team.GetName()),
-			group.WithDescription(team.GetDescription()),
-			group.WithPictureURL(fmt.Sprintf("https://avatars.githubusercontent.com/t/%d?s=116&v=4", team.GetID())),
-			group.WithMemberNames(memberNames...),
-			group.WithParentName(parentTeamName),
-			group.WithGrafanaDashboardSelector(fmt.Sprintf("tags @> 'owner:%s'", team.GetSlug())),
-		)
-		if err != nil {
-			log.Fatalf("Error: could not create group -- %v", err)
-		}
-
-		numGroups++
-		entity := group.ToEntity()
-		err = groupExporter.AddEntity(entity)
-		if err != nil {
-			log.Fatalf("Error: %v", err)
-		}
-	}
-
 	err = componentExporter.WriteFile()
 	if err != nil {
 		log.Fatalf("Error writing components: %v", err)
 	}
-	err = groupExporter.WriteFile()
-	if err != nil {
-		log.Fatalf("Error writing groups: %v", err)
-	}
 
 	fmt.Printf("\n%d components written to file %s with size %d bytes", numComponents, componentExporter.TargetPath, componentExporter.Len())
-	fmt.Printf("\n%d groups written to file %s with size %d bytes", numGroups, groupExporter.TargetPath, groupExporter.Len())
 	fmt.Println("")
 }
 

--- a/docs/usage/README.md
+++ b/docs/usage/README.md
@@ -8,6 +8,7 @@ To run the export, execute
 
 ```nohighlight
 backstage-catalog-importer [--output path-to-output-dir]
+backstage-catalog-importer groups [--output path-to-output-dir]
 backstage-catalog-importer users --internal [--output path-to-output-dir]
 ```
 
@@ -17,9 +18,9 @@ As a result, several YAML files will be written to the output directory. Progres
 
 The following data will be included in the generated catalog:
 
-- All repositories referenced in the repositories lists in [giantswarm/github](https://github.com/giantswarm/github/tree/main/repositories) as _Component_ entities.
-- All teams of the configured Github organizaiton as _Group_ entities.
-- All members of the above teams as _User_ entities.
+- All repositories referenced in the repositories lists in [giantswarm/github](https://github.com/giantswarm/github/tree/main/repositories) as _Component_ entities (root command).
+- All teams of the configured Github organizaiton as _Group_ entities (`groups` command).
+- All members of the above teams as _User_ entities (`users` command).
 
 ## Generate catalog files for customer catalogs
 


### PR DESCRIPTION
### What does this PR do?

Adds a dedicated `groups` subcommand that exports Giant Swarm GitHub teams as Backstage _Group_ entities into `groups.yaml`, following the one-command-per-entity pattern of `charts`/`crd`/`users`/`installations`.

It also removes the (now duplicate) group-export logic from the root command, along with the GitHub teams service the root command only used for that purpose.

### What is the effect of this change to users?

- A new command is available: `backstage-catalog-importer groups [--output path]`.
- The root command no longer writes `groups.yaml` — only `components.yaml`. Component ownership is unaffected, since it is sourced from the repositories metadata service (`repoService.GetLists()` → `OwnerTeamName`), not the teams service.

> [!NOTE]
> To actually fix the stale `catalogs/groups.yaml`, a follow-up PR in `giantswarm/backstage-catalogs` must add a `backstage-catalog-importer groups --output ./catalogs` invocation to `.github/workflows/update-catalogs.yaml`.

### How does it look like?

```
$ backstage-catalog-importer groups --help
Exports Giant Swarm GitHub teams as Backstage group entities.

Usage:
  backstage-catalog-importer groups [flags]

Flags:
  -h, --help   help for groups

Global Flags:
  -o, --output string   Output directory path (default ".")
```

### Any background context you can provide?

Resolves giantswarm/giantswarm#36085.

`groups.yaml` stopped being updated after the `appcatalogs` subcommand (which produced it) was removed in #447. This brings that functionality back as its own command.

### What is needed from the reviewers?

Normal review. Note in particular the ownership-dependency reasoning above (removing the teams service from root is safe).

### Do the docs need to be updated?

Done — `docs/usage/README.md` updated.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
