### PR TITLE
feat: emit CI/release/upstream catalog tags from repo config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add a `groups` subcommand that exports Giant Swarm GitHub teams as Backstage group entities to `groups.yaml`.
 - The `groups` subcommand supports a `--teams` flag (comma-separated allowlist of team slugs) and a `--parent` flag (only export teams that are descendants of the given parent team, e.g. `employees`) to control which teams are exported.
+- Emit additional component tags from the github repo configuration so the devportal catalog can be filtered company-wide by CI/release shape: `ci-generated` (when `gen.ci.generate` is set), `release:auto-release` / `release:legacy` (the effective release workflow), `upstream-check` (when `upstreamCheck` is configured), and `precommit` (when `gen.preCommit` is set).
 
 ### Changed
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -208,6 +208,20 @@ func runRoot(cmd *cobra.Command, args []string) {
 				c.AddTag("helmchart-deployable")
 			}
 
+			// Surface github repo-config settings as filterable catalog tags so
+			// the devportal catalog can be sliced company-wide by CI/release
+			// shape, not just team/type/flavour/language.
+			if repo.Gen.CI.Generate {
+				c.AddTag("ci-generated")
+			}
+			c.AddTag("release:" + repo.EffectiveReleaseWorkflow())
+			if repo.HasUpstreamCheck() {
+				c.AddTag("upstream-check")
+			}
+			if len(repo.Gen.PreCommit) > 0 {
+				c.AddTag("precommit")
+			}
+
 			if len(charts) > 0 {
 				// Determine the chart's audience annotation, and if 'all', add tag.
 				// (This ignores the rare case where a repo may have more than one chart with different audience annotations.)

--- a/pkg/input/repositories/repositories_test.go
+++ b/pkg/input/repositories/repositories_test.go
@@ -94,6 +94,38 @@ workflows:
 	}
 }
 
+func TestEffectiveReleaseWorkflow(t *testing.T) {
+	tests := []struct {
+		name string
+		repo Repo
+		want string
+	}{
+		{
+			name: "explicit value wins over CI default",
+			repo: Repo{Gen: RepoGen{CI: RepoCI{Generate: true, ReleaseWorkflow: "legacy"}}},
+			want: "legacy",
+		},
+		{
+			name: "generated CI implies auto-release",
+			repo: Repo{Gen: RepoGen{CI: RepoCI{Generate: true}}},
+			want: "auto-release",
+		},
+		{
+			name: "no CI defaults to legacy",
+			repo: Repo{Name: "name-only"},
+			want: "legacy",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.repo.EffectiveReleaseWorkflow(); got != tt.want {
+				t.Errorf("EffectiveReleaseWorkflow() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestLoadListShallow(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -190,6 +222,23 @@ func TestLoadList(t *testing.T) {
 						ArchitectOrb: false,
 						PreCommit:    true,
 						Renovate:     true,
+					},
+				},
+				{
+					Name:          "repo-with-ci-and-upstream",
+					ComponentType: "service",
+					Gen: RepoGen{
+						Flavors:   []RepoFlavor{RepoFlavorApp},
+						Language:  RepoLanguageGo,
+						PreCommit: []string{"helmchart"},
+						CI: RepoCI{
+							Generate:        true,
+							ReleaseWorkflow: "legacy",
+						},
+					},
+					UpstreamCheck: &RepoUpstreamCheck{
+						ChartPath:    "helm/foo",
+						UpstreamRepo: "org/foo",
 					},
 				},
 			},

--- a/pkg/input/repositories/testdata/artificial.yaml
+++ b/pkg/input/repositories/testdata/artificial.yaml
@@ -19,3 +19,17 @@
     architect-orb: false
     renovate: true
     precommit: true
+- name: repo-with-ci-and-upstream
+  componentType: service
+  gen:
+    flavours:
+    - app
+    language: go
+    preCommit:
+    - helmchart
+    ci:
+      generate: true
+      releaseWorkflow: legacy
+  upstreamCheck:
+    chartPath: helm/foo
+    upstreamRepo: org/foo

--- a/pkg/input/repositories/types.go
+++ b/pkg/input/repositories/types.go
@@ -2,13 +2,34 @@ package repositories
 
 // Repo represents an entry in the giantswarm/github repositories YAML data.
 type Repo struct {
-	Name          string           `yaml:"name"`
-	ComponentType string           `yaml:"componentType"`
-	System        string           `yaml:"system"`
-	Gen           RepoGen          `yaml:"gen"`
-	Lifecycle     RepoLifecycle    `yaml:"lifecycle"`
-	Replacements  RepoReplacements `yaml:"replace"`
-	AppTestSuite  interface{}      `yaml:"app_test_suite"`
+	Name          string             `yaml:"name"`
+	ComponentType string             `yaml:"componentType"`
+	System        string             `yaml:"system"`
+	Gen           RepoGen            `yaml:"gen"`
+	Lifecycle     RepoLifecycle      `yaml:"lifecycle"`
+	Replacements  RepoReplacements   `yaml:"replace"`
+	AppTestSuite  interface{}        `yaml:"app_test_suite"`
+	UpstreamCheck *RepoUpstreamCheck `yaml:"upstreamCheck"`
+}
+
+// HasUpstreamCheck reports whether the repo opted into the monthly upstream
+// update check.
+func (r Repo) HasUpstreamCheck() bool {
+	return r.UpstreamCheck != nil
+}
+
+// EffectiveReleaseWorkflow returns the release workflow that applies to the
+// repo, mirroring the default logic in github's repositories.schema.json: an
+// explicit gen.ci.releaseWorkflow wins; otherwise a devctl-generated CI surface
+// (gen.ci.generate) implies "auto-release", and everything else is "legacy".
+func (r Repo) EffectiveReleaseWorkflow() string {
+	if r.Gen.CI.ReleaseWorkflow != "" {
+		return string(r.Gen.CI.ReleaseWorkflow)
+	}
+	if r.Gen.CI.Generate {
+		return "auto-release"
+	}
+	return "legacy"
 }
 
 type RepoFlavor string
@@ -31,6 +52,23 @@ type RepoGen struct {
 	Flavors            []RepoFlavor `yaml:"flavours"`
 	Language           RepoLanguage `yaml:"language"`
 	InstallUpdateChart bool         `yaml:"installUpdateChart"`
+	PreCommit          []string     `yaml:"preCommit"`
+	CI                 RepoCI       `yaml:"ci"`
+}
+
+// RepoCI holds the gen.ci block: whether devctl generates the CI surface and
+// which release workflow it produces.
+type RepoCI struct {
+	Generate        bool   `yaml:"generate"`
+	ReleaseWorkflow string `yaml:"releaseWorkflow"`
+}
+
+// RepoUpstreamCheck holds the upstreamCheck block that opts a repo into the
+// monthly upstream update check.
+type RepoUpstreamCheck struct {
+	ChartPath     string `yaml:"chartPath"`
+	UpstreamRepo  string `yaml:"upstreamRepo"`
+	ReleasePrefix string `yaml:"releasePrefix"`
 }
 
 type RepoReplacements struct {


### PR DESCRIPTION
## Problem

The devportal Software Catalog already lets teams filter the whole company's repos by team (`owner`), `type`, `system`, `lifecycle`, `flavor:*` and `language:*`. But several settings tracked in `giantswarm/github`'s `repositories/*.yaml` are never projected into the catalog, so they can't be filtered on: whether CI is devctl-generated, which release workflow applies, whether the repo opts into the monthly upstream check, and whether it generates a pre-commit config.

## Proposed solution

Parse the missing blocks from the repo config and emit them as filterable component tags:

| Tag | Source |
|---|---|
| `ci-generated` | `gen.ci.generate: true` |
| `release:auto-release` / `release:legacy` | effective release workflow (explicit `gen.ci.releaseWorkflow` wins; else `gen.ci.generate` ⇒ `auto-release`; else `legacy` — mirrors the default in github's `repositories.schema.json`) |
| `upstream-check` | `upstreamCheck` configured |
| `precommit` | `gen.preCommit` configured |

Tags are the filterable surface in the Backstage catalog; colons survive `NormalizeTags` exactly as the existing `flavor:app` / `language:go` tags do.

- `pkg/input/repositories/types.go` — parse `gen.ci`, `gen.preCommit`, `upstreamCheck`; add `Repo.EffectiveReleaseWorkflow()` and `Repo.HasUpstreamCheck()`.
- `cmd/root.go` — emit the four tags during component assembly.
- `repositories_test.go` + `testdata/artificial.yaml` — extended deep-parse case and a `TestEffectiveReleaseWorkflow` unit test.

## Acceptance criteria

- [ ] Generated component entities carry the new tags where applicable.
- [ ] `EffectiveReleaseWorkflow` matches the schema default precedence.
- [ ] Existing tags/labels/annotations are unchanged.

Once released, the github repo's `update-devportal-catalog.yaml` workflow needs its pinned importer version bumped to pick up the new tags (follow-up PR).

Made with [Cursor](https://cursor.com)