### PR TITLE
feat: add team filtering to groups subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add a `groups` subcommand that exports Giant Swarm GitHub teams as Backstage group entities to `groups.yaml`.
+- The `groups` subcommand supports a `--teams` flag (comma-separated allowlist of team slugs) and a `--parent` flag (only export teams that are descendants of the given parent team, e.g. `employees`) to control which teams are exported.
+
+### Changed
+
+- The `groups` subcommand now requires at least one of `--teams` or `--parent` to be set. This prevents accidentally exporting all teams, which can expose sensitive (e.g. customer-specific) team names.
 
 ### Removed
 

--- a/cmd/groups/groups.go
+++ b/cmd/groups/groups.go
@@ -17,14 +17,50 @@ import (
 // Name of the GitHub organization owning our teams and users.
 const githubOrganization = "giantswarm"
 
+const (
+	teamsFlag  = "teams"
+	parentFlag = "parent"
+)
+
 var Command = &cobra.Command{
 	Use:   "groups",
 	Short: "Export groups catalog",
-	Long:  `Exports Giant Swarm GitHub teams as Backstage group entities.`,
-	RunE:  run,
+	Long: `Exports Giant Swarm GitHub teams as Backstage group entities.
+
+To avoid exposing sensitive team names (for example customer-specific teams), at
+least one filter must be given:
+
+  --teams   Comma-separated allowlist of team slugs to export. Only teams in this
+            list are exported.
+  --parent  Only export teams that are descendants of this team slug (for example
+            "employees").
+
+When both are given, a team is exported only if it is in the allowlist AND a
+descendant of the parent team.`,
+	RunE: run,
+}
+
+func init() {
+	Command.Flags().StringSlice(teamsFlag, nil, "Allowlist of team slugs to export (comma-separated). Only these teams are exported.")
+	Command.Flags().String(parentFlag, "", `Only export teams that are descendants of this parent team slug (e.g. "employees").`)
 }
 
 func run(cmd *cobra.Command, args []string) error {
+	allowedTeams, err := cmd.Flags().GetStringSlice(teamsFlag)
+	if err != nil {
+		return err
+	}
+	parent, err := cmd.Flags().GetString(parentFlag)
+	if err != nil {
+		return err
+	}
+
+	// Require an explicit filter to avoid accidentally exporting all teams,
+	// which may expose sensitive (e.g. customer) team names.
+	if len(allowedTeams) == 0 && parent == "" {
+		log.Fatalf("Error: refusing to export all teams. Specify --%s and/or --%s to select which teams to expose.", teamsFlag, parentFlag)
+	}
+
 	token := os.Getenv("GITHUB_TOKEN")
 	if token == "" {
 		log.Fatal("Please set environment variable GITHUB_TOKEN to a personal GitHub access token (PAT).")
@@ -43,17 +79,38 @@ func run(cmd *cobra.Command, args []string) error {
 		log.Fatalf("Error: could not create teams service -- %v", err)
 	}
 
-	groupExporter := export.New(export.Config{TargetPath: path + "/groups.yaml"})
-
 	teamsList, err := teamsService.GetAll()
 	if err != nil {
 		log.Fatalf("Error: %v", err)
 	}
-	log.Printf("Processing %d teams", len(teamsList))
+	log.Printf("Found %d teams in total", len(teamsList))
+
+	// Map of team slug -> parent slug, used to resolve team ancestry.
+	parentBySlug := make(map[string]string, len(teamsList))
+	for _, t := range teamsList {
+		parentBySlug[t.GetSlug()] = t.GetParent().GetSlug()
+	}
+
+	allowSet := make(map[string]bool, len(allowedTeams))
+	for _, s := range allowedTeams {
+		allowSet[s] = true
+	}
+
+	groupExporter := export.New(export.Config{TargetPath: path + "/groups.yaml"})
 
 	numGroups := 0
+	exported := make(map[string]bool)
 	for _, team := range teamsList {
-		members, err := teamsService.GetMembers(team.GetSlug())
+		slug := team.GetSlug()
+
+		if len(allowSet) > 0 && !allowSet[slug] {
+			continue
+		}
+		if parent != "" && !isDescendant(slug, parent, parentBySlug) {
+			continue
+		}
+
+		members, err := teamsService.GetMembers(slug)
 		if err != nil {
 			log.Fatalf("Error: %v", err)
 		}
@@ -72,7 +129,16 @@ func run(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			log.Fatalf("Error: %v", err)
 		}
+		exported[slug] = true
 		numGroups++
+	}
+
+	// Warn about allowlisted teams that were not exported, which usually means a
+	// typo in the slug or exclusion by the --parent filter.
+	for _, s := range allowedTeams {
+		if !exported[s] {
+			log.Printf("WARN: allowlisted team %q was not exported (not found or excluded by --%s)", s, parentFlag)
+		}
 	}
 
 	err = groupExporter.WriteFile()
@@ -83,6 +149,24 @@ func run(cmd *cobra.Command, args []string) error {
 	fmt.Printf("\n%d groups written to file %s with size %d bytes\n", numGroups, groupExporter.TargetPath, groupExporter.Len())
 
 	return nil
+}
+
+// isDescendant reports whether the team identified by slug is a (transitive)
+// descendant of ancestor, following the parent chain in parentBySlug. The
+// ancestor team itself is not considered its own descendant. It guards against
+// cycles in the (otherwise tree-shaped) hierarchy.
+func isDescendant(slug, ancestor string, parentBySlug map[string]string) bool {
+	seen := map[string]bool{slug: true}
+	for cur := parentBySlug[slug]; cur != ""; cur = parentBySlug[cur] {
+		if cur == ancestor {
+			return true
+		}
+		if seen[cur] {
+			break
+		}
+		seen[cur] = true
+	}
+	return false
 }
 
 // groupFromTeam builds a Backstage group from a GitHub team and its member logins.

--- a/cmd/groups/groups_test.go
+++ b/cmd/groups/groups_test.go
@@ -7,6 +7,45 @@ import (
 	"github.com/google/go-github/v88/github"
 )
 
+func TestIsDescendant(t *testing.T) {
+	// Hierarchy:
+	//   employees
+	//     ├── team-atlas
+	//     │     └── team-atlas-sub
+	//     └── ae-adidas
+	//   bots            (no parent)
+	parentBySlug := map[string]string{
+		"employees":      "",
+		"team-atlas":     "employees",
+		"team-atlas-sub": "team-atlas",
+		"ae-adidas":      "employees",
+		"bots":           "",
+	}
+
+	testCases := []struct {
+		slug     string
+		ancestor string
+		expected bool
+	}{
+		{slug: "team-atlas", ancestor: "employees", expected: true},       // direct child
+		{slug: "team-atlas-sub", ancestor: "employees", expected: true},   // transitive descendant
+		{slug: "ae-adidas", ancestor: "employees", expected: true},        // customer team is also under employees
+		{slug: "employees", ancestor: "employees", expected: false},       // a team is not its own descendant
+		{slug: "bots", ancestor: "employees", expected: false},            // unrelated top-level team
+		{slug: "team-atlas", ancestor: "team-atlas-sub", expected: false}, // ancestor/descendant reversed
+		{slug: "unknown", ancestor: "employees", expected: false},         // unknown slug
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.slug+"_in_"+tc.ancestor, func(t *testing.T) {
+			got := isDescendant(tc.slug, tc.ancestor, parentBySlug)
+			if got != tc.expected {
+				t.Errorf("isDescendant(%q, %q): got %v, want %v", tc.slug, tc.ancestor, got, tc.expected)
+			}
+		})
+	}
+}
+
 func TestGroupFromTeam(t *testing.T) {
 	testCases := []struct {
 		name        string

--- a/docs/usage/README.md
+++ b/docs/usage/README.md
@@ -8,9 +8,11 @@ To run the export, execute
 
 ```nohighlight
 backstage-catalog-importer [--output path-to-output-dir]
-backstage-catalog-importer groups [--output path-to-output-dir]
+backstage-catalog-importer groups --parent employees [--output path-to-output-dir]
 backstage-catalog-importer users --internal [--output path-to-output-dir]
 ```
+
+The `groups` command requires at least one of `--teams` (a comma-separated allowlist of team slugs) or `--parent` (only export teams that are descendants of the given parent team) to be set. This is a safeguard against accidentally exporting all teams, which can expose sensitive (e.g. customer-specific) team names. For customer-facing catalogs, prefer an explicit `--teams` allowlist.
 
 As a result, several YAML files will be written to the output directory. Progress and warnings will be logged to the console.
 


### PR DESCRIPTION
### What does this PR do?

Adds two filtering flags to the `groups` subcommand and makes a filter mandatory:

- `--teams` — comma-separated **allowlist** of team slugs to export.
- `--parent` — only export teams that are **descendants** of the given parent team (e.g. `employees`).

At least one of the two must be provided; otherwise the command refuses to run. When both are given, a team is exported only if it is in the allowlist **and** a descendant of the parent.

### What is the effect of this change to users?

Catalog generators can now select exactly which teams are exported, instead of always exporting every GitHub team in the organization.

> [!IMPORTANT]
> This is a **breaking change** to the `groups` command introduced in v0.30.0: running `groups` with no flags now errors. Consumers must pass a flag, e.g. `groups --parent employees` or `groups --teams team-atlas,team-honeybadger,team-shield`.

### How does it look like?

```
$ backstage-catalog-importer groups
Error: refusing to export all teams. Specify --teams and/or --parent to select which teams to expose.

$ backstage-catalog-importer groups --parent employees --output ./catalog
# exports all teams under the "employees" team
```

### Any background context you can provide?

Follow-up to #542. Note that the `--parent` and `--teams` filters are independent: a team can be a descendant of a parent and still need to be excluded, so an explicit `--teams` allowlist is the way to restrict output to a known-safe set.

### What is needed from the reviewers?

Confirm the flag semantics.

### Do the docs need to be updated?

Done — `docs/usage/README.md` updated.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)