### PR TITLE
feat: add --namespace flag to groups and make entity sort stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add a `groups` subcommand that exports Giant Swarm GitHub teams as Backstage group entities to `groups.yaml`.
 - The `groups` subcommand supports a `--teams` flag (comma-separated allowlist of team slugs) and a `--parent` flag (only export teams that are descendants of the given parent team, e.g. `employees`) to control which teams are exported.
+- The `groups` subcommand supports a `--namespace` flag (default `default`). Set it to an empty string to omit the `namespace` field from exported group entities (e.g. for customer-facing catalogs).
 - Emit additional component tags from the github repo configuration so the devportal catalog can be filtered company-wide by CI/release shape: `ci-generated` (when `gen.ci.generate` is set), `release:auto-release` / `release:legacy` (the effective release workflow), `upstream-check` (when `upstreamCheck` is configured), and `precommit` (when `gen.preCommit` is set).
 
 ### Changed
 
 - The `groups` subcommand now requires at least one of `--teams` or `--parent` to be set. This prevents accidentally exporting all teams, which can expose sensitive (e.g. customer-specific) team names.
+- Exported catalog entities are now sorted with a stable sort, so the output ordering is fully deterministic across runs and diffs stay minimal.
 
 ### Removed
 

--- a/cmd/groups/groups.go
+++ b/cmd/groups/groups.go
@@ -18,8 +18,11 @@ import (
 const githubOrganization = "giantswarm"
 
 const (
-	teamsFlag  = "teams"
-	parentFlag = "parent"
+	teamsFlag     = "teams"
+	parentFlag    = "parent"
+	namespaceFlag = "namespace"
+
+	defaultNamespace = "default"
 )
 
 var Command = &cobra.Command{
@@ -43,6 +46,7 @@ descendant of the parent team.`,
 func init() {
 	Command.Flags().StringSlice(teamsFlag, nil, "Allowlist of team slugs to export (comma-separated). Only these teams are exported.")
 	Command.Flags().String(parentFlag, "", `Only export teams that are descendants of this parent team slug (e.g. "employees").`)
+	Command.Flags().StringP(namespaceFlag, "n", defaultNamespace, "Backstage namespace for the exported groups. Set to an empty string to omit the namespace field.")
 }
 
 func run(cmd *cobra.Command, args []string) error {
@@ -51,6 +55,10 @@ func run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	parent, err := cmd.Flags().GetString(parentFlag)
+	if err != nil {
+		return err
+	}
+	namespace, err := cmd.Flags().GetString(namespaceFlag)
 	if err != nil {
 		return err
 	}
@@ -120,7 +128,7 @@ func run(cmd *cobra.Command, args []string) error {
 			memberNames = append(memberNames, u.GetLogin())
 		}
 
-		g, err := groupFromTeam(team, memberNames)
+		g, err := groupFromTeam(team, memberNames, namespace)
 		if err != nil {
 			log.Fatalf("Error: could not create group -- %v", err)
 		}
@@ -169,14 +177,16 @@ func isDescendant(slug, ancestor string, parentBySlug map[string]string) bool {
 	return false
 }
 
-// groupFromTeam builds a Backstage group from a GitHub team and its member logins.
-func groupFromTeam(team *github.Team, memberNames []string) (*group.Group, error) {
+// groupFromTeam builds a Backstage group from a GitHub team and its member
+// logins. An empty namespace omits the namespace field from the entity.
+func groupFromTeam(team *github.Team, memberNames []string, namespace string) (*group.Group, error) {
 	parentTeamName := ""
 	if team.GetParent() != nil {
 		parentTeamName = team.GetParent().GetSlug()
 	}
 
 	return group.New(team.GetSlug(),
+		group.WithNamespace(namespace),
 		group.WithTitle(team.GetName()),
 		group.WithDescription(team.GetDescription()),
 		group.WithPictureURL(fmt.Sprintf("https://avatars.githubusercontent.com/t/%d?s=116&v=4", team.GetID())),

--- a/cmd/groups/groups_test.go
+++ b/cmd/groups/groups_test.go
@@ -51,14 +51,16 @@ func TestGroupFromTeam(t *testing.T) {
 		name        string
 		team        *github.Team
 		memberNames []string
+		namespace   string
 
-		expectedName     string
-		expectedTitle    string
-		expectedDesc     string
-		expectedPicture  string
-		expectedParent   string
-		expectedSelector string
-		expectedMembers  []string
+		expectedName      string
+		expectedNamespace string
+		expectedTitle     string
+		expectedDesc      string
+		expectedPicture   string
+		expectedParent    string
+		expectedSelector  string
+		expectedMembers   []string
 	}{
 		{
 			name: "team without parent and with members",
@@ -68,14 +70,16 @@ func TestGroupFromTeam(t *testing.T) {
 				Name:        github.Ptr("Honey Badger"),
 				Description: github.Ptr("The honey badger team"),
 			},
-			memberNames:      []string{"bob", "alice"},
-			expectedName:     "team-honeybadger",
-			expectedTitle:    "Honey Badger",
-			expectedDesc:     "The honey badger team",
-			expectedPicture:  "https://avatars.githubusercontent.com/t/123?s=116&v=4",
-			expectedParent:   "",
-			expectedSelector: "tags @> 'owner:team-honeybadger'",
-			expectedMembers:  []string{"bob", "alice"},
+			memberNames:       []string{"bob", "alice"},
+			namespace:         "default",
+			expectedName:      "team-honeybadger",
+			expectedNamespace: "default",
+			expectedTitle:     "Honey Badger",
+			expectedDesc:      "The honey badger team",
+			expectedPicture:   "https://avatars.githubusercontent.com/t/123?s=116&v=4",
+			expectedParent:    "",
+			expectedSelector:  "tags @> 'owner:team-honeybadger'",
+			expectedMembers:   []string{"bob", "alice"},
 		},
 		{
 			name: "team with parent and no members",
@@ -88,26 +92,49 @@ func TestGroupFromTeam(t *testing.T) {
 					Slug: github.Ptr("team-parent"),
 				},
 			},
-			memberNames:      nil,
-			expectedName:     "team-bumblebee",
-			expectedTitle:    "Bumblebee",
-			expectedDesc:     "",
-			expectedPicture:  "https://avatars.githubusercontent.com/t/456?s=116&v=4",
-			expectedParent:   "team-parent",
-			expectedSelector: "tags @> 'owner:team-bumblebee'",
-			expectedMembers:  nil,
+			memberNames:       nil,
+			namespace:         "default",
+			expectedName:      "team-bumblebee",
+			expectedNamespace: "default",
+			expectedTitle:     "Bumblebee",
+			expectedDesc:      "",
+			expectedPicture:   "https://avatars.githubusercontent.com/t/456?s=116&v=4",
+			expectedParent:    "team-parent",
+			expectedSelector:  "tags @> 'owner:team-bumblebee'",
+			expectedMembers:   nil,
+		},
+		{
+			name: "empty namespace is omitted",
+			team: &github.Team{
+				ID:   github.Ptr(int64(789)),
+				Slug: github.Ptr("team-shield"),
+				Name: github.Ptr("Shield"),
+			},
+			memberNames:       []string{"carol"},
+			namespace:         "",
+			expectedName:      "team-shield",
+			expectedNamespace: "",
+			expectedTitle:     "Shield",
+			expectedDesc:      "",
+			expectedPicture:   "https://avatars.githubusercontent.com/t/789?s=116&v=4",
+			expectedParent:    "",
+			expectedSelector:  "tags @> 'owner:team-shield'",
+			expectedMembers:   []string{"carol"},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			g, err := groupFromTeam(tc.team, tc.memberNames)
+			g, err := groupFromTeam(tc.team, tc.memberNames, tc.namespace)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
 			if g.Name != tc.expectedName {
 				t.Errorf("Name: got %q, want %q", g.Name, tc.expectedName)
+			}
+			if g.Namespace != tc.expectedNamespace {
+				t.Errorf("Namespace: got %q, want %q", g.Namespace, tc.expectedNamespace)
 			}
 			if g.Title != tc.expectedTitle {
 				t.Errorf("Title: got %q, want %q", g.Title, tc.expectedTitle)
@@ -126,6 +153,11 @@ func TestGroupFromTeam(t *testing.T) {
 			}
 			if !reflect.DeepEqual(g.MemberNames, tc.expectedMembers) {
 				t.Errorf("MemberNames: got %v, want %v", g.MemberNames, tc.expectedMembers)
+			}
+
+			// ToEntity mutates the group (it sorts members), so assert on it last.
+			if ns := g.ToEntity().Metadata.Namespace; ns != tc.expectedNamespace {
+				t.Errorf("Entity namespace: got %q, want %q", ns, tc.expectedNamespace)
 			}
 		})
 	}

--- a/docs/usage/README.md
+++ b/docs/usage/README.md
@@ -14,6 +14,8 @@ backstage-catalog-importer users --internal [--output path-to-output-dir]
 
 The `groups` command requires at least one of `--teams` (a comma-separated allowlist of team slugs) or `--parent` (only export teams that are descendants of the given parent team) to be set. This is a safeguard against accidentally exporting all teams, which can expose sensitive (e.g. customer-specific) team names. For customer-facing catalogs, prefer an explicit `--teams` allowlist.
 
+By default the exported groups use the `default` namespace. Pass `--namespace ""` to omit the `namespace` field entirely, which is recommended for customer-facing catalogs.
+
 As a result, several YAML files will be written to the output directory. Progress and warnings will be logged to the console.
 
 ### What's covered

--- a/pkg/output/export/export.go
+++ b/pkg/output/export/export.go
@@ -64,7 +64,7 @@ func (s *Service) updateBuffer() error {
 func (s *Service) AddEntity(entity *bscatalog.Entity) error {
 	s.collection = append(s.collection, entity)
 
-	slices.SortFunc(s.collection, func(a, b *bscatalog.Entity) int {
+	slices.SortStableFunc(s.collection, func(a, b *bscatalog.Entity) int {
 		return cmp.Or(
 			cmp.Compare(a.APIVersion, b.APIVersion),
 			cmp.Compare(a.Kind, b.Kind),


### PR DESCRIPTION
### What does this PR do?

Two improvements to the `groups` export:

1. **`--namespace` flag** (default `default`). Setting it to an empty string omits the `namespace` field from exported group entities. Backstage treats an absent namespace as `default`, so existing `group:default/...` owner references still resolve.
2. **Stable entity sort.** The export layer already sorted entities by `(apiVersion, kind, namespace, name)`; this switches it to a stable sort so ordering is fully deterministic across runs and diffs stay minimal.

### What is the effect of this change to users?

- Catalog generators can omit the redundant `namespace: default` line (e.g. `groups --namespace ""`).
- Generated files have deterministic ordering.

### How does it look like?

```
$ backstage-catalog-importer groups --parent employees --namespace "" --output ./catalogs
# group entities written without a `namespace:` field
```

### Any background context you can provide?

Follow-up to #542 and #544. Consistent with the earlier direction in v0.26.3 ("namespace should be determined by the default logic, not hardcoded" for customer catalogs).

### What is needed from the reviewers?

Confirm the flag default (`default`) and the empty-string-to-omit semantics.

### Do the docs need to be updated?

Done — `docs/usage/README.md` updated.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)