### PR TITLE
feat: emit CI-generation as a value tag (ci:generated / ci:manual)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Emit the CI-generation state as a value tag (`ci:generated` / `ci:manual`, always exactly one) instead of the presence-only `ci-generated`. The catalog tag picker only ANDs positive tags, so a complement tag is needed to express queries like "auto-release but not devctl-generated CI" (`release:auto-release` + `ci:manual`).
+
 ### Added
 
 - Add a `groups` subcommand that exports Giant Swarm GitHub teams as Backstage group entities to `groups.yaml`.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -211,8 +211,13 @@ func runRoot(cmd *cobra.Command, args []string) {
 			// Surface github repo-config settings as filterable catalog tags so
 			// the devportal catalog can be sliced company-wide by CI/release
 			// shape, not just team/type/flavour/language.
+			// Value tag (always exactly one) so the catalog tag picker, which
+			// only ANDs positive tags, can select both "generated" and the
+			// complement "manual" -- e.g. release:auto-release + ci:manual.
 			if repo.Gen.CI.Generate {
-				c.AddTag("ci-generated")
+				c.AddTag("ci:generated")
+			} else {
+				c.AddTag("ci:manual")
 			}
 			c.AddTag("release:" + repo.EffectiveReleaseWorkflow())
 			if repo.HasUpstreamCheck() {


### PR DESCRIPTION
## Problem

The presence-only `ci-generated` tag (added in #543) cannot express the query "repos on auto-release but **without** devctl-generated CI". The Backstage catalog tag picker only ANDs *positive* tags — there's no exclusion — so `release:auto-release` AND NOT `ci-generated` is inexpressible.

## Proposed solution

Emit the CI-generation state as a value tag, always exactly one of `ci:generated` / `ci:manual`, mirroring the existing `release:auto-release` / `release:legacy`. The query then becomes two positive tags the AND-picker handles: `release:auto-release` + `ci:manual`.

## Acceptance criteria

- [ ] Every component carries exactly one of `ci:generated` / `ci:manual`.
- [ ] The presence-only `ci-generated` tag is removed.

Made with [Cursor](https://cursor.com)